### PR TITLE
fix(device_handle): Allow SET_IDLE requests with direction out

### DIFF
--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -326,7 +326,10 @@ impl<'a> DeviceHandle<'a> {
     /// * `NoDevice` if the device has been disconnected.
     /// * `Io` if the transfer encountered an I/O error.
     pub fn read_control(&mut self, request_type: u8, request: u8, value: u16, index: u16, buf: &mut [u8], timeout: Duration) -> ::Result<usize> {
-        if request_type & ::libusb::LIBUSB_ENDPOINT_DIR_MASK != ::libusb::LIBUSB_ENDPOINT_IN {
+        // only Direction::In is allowed, except for SET_IDLE requests (request 0x0a), where
+        //     Direction::Out is allowed
+        if request_type & ::libusb::LIBUSB_ENDPOINT_DIR_MASK != ::libusb::LIBUSB_ENDPOINT_IN
+                && request != 0x0a {
             return Err(::Error::InvalidParam);
         }
 


### PR DESCRIPTION
The SET_IDLE request (bRequest 0x0a) have a bmRequestType of 0x21. Using
this request_type in libusb-rs DeviceHandle::read_control gets rejected
with an InvalidParam, because it's direction is not Direction::In, but
rather Direction::Out (when parsed as direction).

This Pull Request adds another condition to the request_type Mask-Check,
allowing SET_IDLE requests of `request == 0x0a` to pass through the check
with Direction::Out set.