### PR TITLE
Fix use-after-free in tests, and mark corresponding functions unsafe

### DIFF
--- a/src/config_descriptor.rs
+++ b/src/config_descriptor.rs
@@ -108,7 +108,7 @@ impl<'a> Iterator for Interfaces<'a> {
 
     fn next(&mut self) -> Option<Interface<'a>> {
         self.iter.next().map(|interface| {
-            ::interface_descriptor::from_libusb(interface)
+            unsafe { ::interface_descriptor::from_libusb(interface) }
         })
     }
 
@@ -119,7 +119,7 @@ impl<'a> Iterator for Interfaces<'a> {
 
 
 #[doc(hidden)]
-pub fn from_libusb(config: *const ::libusb::libusb_config_descriptor) -> ConfigDescriptor {
+pub unsafe fn from_libusb(config: *const ::libusb::libusb_config_descriptor) -> ConfigDescriptor {
     ConfigDescriptor { descriptor: config }
 }
 
@@ -137,7 +137,7 @@ mod test {
     macro_rules! with_config {
         ($name:ident : $config:expr => $body:block) => {
             {
-                let $name = super::from_libusb(&$config);
+                let $name = unsafe { super::from_libusb(&$config) };
                 $body;
                 mem::forget($name);
             }

--- a/src/context.rs
+++ b/src/context.rs
@@ -73,7 +73,7 @@ impl Context {
             Err(::error::from_libusb(n as c_int))
         }
         else {
-            Ok(::device_list::from_libusb(self, list, n as usize))
+            Ok(unsafe { ::device_list::from_libusb(self, list, n as usize) })
         }
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -40,7 +40,7 @@ impl<'a> Device<'a> {
 
         try_unsafe!(::libusb::libusb_get_config_descriptor(self.device, config_index, &mut config));
 
-        Ok(::config_descriptor::from_libusb(config))
+        Ok(unsafe { ::config_descriptor::from_libusb(config) })
     }
 
     /// Returns the number of the bus that the device is connected to.
@@ -70,13 +70,13 @@ impl<'a> Device<'a> {
 
         try_unsafe!(::libusb::libusb_open(self.device, &mut handle));
 
-        Ok(::device_handle::from_libusb(self.context, handle))
+        Ok(unsafe { ::device_handle::from_libusb(self.context, handle) })
     }
 }
 
 #[doc(hidden)]
-pub fn from_libusb<'a>(context: PhantomData<&'a Context>, device: *mut ::libusb::libusb_device) -> Device<'a> {
-    unsafe { ::libusb::libusb_ref_device(device) };
+pub unsafe fn from_libusb<'a>(context: PhantomData<&'a Context>, device: *mut ::libusb::libusb_device) -> Device<'a> {
+    ::libusb::libusb_ref_device(device);
 
     Device {
         context: context,

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -489,7 +489,7 @@ impl<'a> DeviceHandle<'a> {
 }
 
 #[doc(hidden)]
-pub fn from_libusb<'a>(context: PhantomData<&'a Context>, handle: *mut ::libusb::libusb_device_handle) -> DeviceHandle<'a> {
+pub unsafe fn from_libusb<'a>(context: PhantomData<&'a Context>, handle: *mut ::libusb::libusb_device_handle) -> DeviceHandle<'a> {
     DeviceHandle {
         _context: context,
         handle: handle,

--- a/src/device_list.rs
+++ b/src/device_list.rs
@@ -54,7 +54,7 @@ impl<'a, 'b> Iterator for Devices<'a, 'b> {
             let device = self.devices[self.index];
 
             self.index += 1;
-            Some(::device::from_libusb(self.context, device))
+            Some(unsafe { ::device::from_libusb(self.context, device) })
         }
         else {
             None
@@ -69,7 +69,7 @@ impl<'a, 'b> Iterator for Devices<'a, 'b> {
 
 
 #[doc(hidden)]
-pub fn from_libusb<'a>(_context: &'a Context, list: *const *mut ::libusb::libusb_device, len: usize,) -> DeviceList<'a> {
+pub unsafe fn from_libusb<'a>(_context: &'a Context, list: *const *mut ::libusb::libusb_device, len: usize,) -> DeviceList<'a> {
     DeviceList {
         context: PhantomData,
         list: list,

--- a/src/interface_descriptor.rs
+++ b/src/interface_descriptor.rs
@@ -142,8 +142,8 @@ impl<'a> Iterator for EndpointDescriptors<'a> {
 
 
 #[doc(hidden)]
-pub fn from_libusb(interface: &::libusb::libusb_interface) -> Interface {
-    let descriptors = unsafe { slice::from_raw_parts(interface.altsetting, interface.num_altsetting as usize) };
+pub unsafe fn from_libusb(interface: &::libusb::libusb_interface) -> Interface {
+    let descriptors = slice::from_raw_parts(interface.altsetting, interface.num_altsetting as usize);
     debug_assert!(descriptors.len() > 0);
 
     Interface { descriptors: descriptors }
@@ -154,42 +154,42 @@ pub fn from_libusb(interface: &::libusb::libusb_interface) -> Interface {
 mod test {
     #[test]
     fn it_has_interface_number() {
-        assert_eq!(42, super::from_libusb(&interface!(interface_descriptor!(bInterfaceNumber: 42))).number());
+        assert_eq!(42, unsafe { super::from_libusb(&interface!(interface_descriptor!(bInterfaceNumber: 42))) }.number());
     }
 
     #[test]
     fn it_has_interface_number_in_descriptor() {
-        assert_eq!(vec!(42), super::from_libusb(&interface!(interface_descriptor!(bInterfaceNumber: 42))).descriptors().map(|setting| setting.interface_number()).collect::<Vec<_>>());
+        assert_eq!(vec!(42), unsafe { super::from_libusb(&interface!(interface_descriptor!(bInterfaceNumber: 42))) }.descriptors().map(|setting| setting.interface_number()).collect::<Vec<_>>());
     }
 
     #[test]
     fn it_has_alternate_setting_number() {
-        assert_eq!(vec!(42), super::from_libusb(&interface!(interface_descriptor!(bAlternateSetting: 42))).descriptors().map(|setting| setting.setting_number()).collect::<Vec<_>>());
+        assert_eq!(vec!(42), unsafe { super::from_libusb(&interface!(interface_descriptor!(bAlternateSetting: 42))) }.descriptors().map(|setting| setting.setting_number()).collect::<Vec<_>>());
     }
 
     #[test]
     fn it_has_class_code() {
-        assert_eq!(vec!(42), super::from_libusb(&interface!(interface_descriptor!(bInterfaceClass: 42))).descriptors().map(|setting| setting.class_code()).collect::<Vec<_>>());
+        assert_eq!(vec!(42), unsafe { super::from_libusb(&interface!(interface_descriptor!(bInterfaceClass: 42))) }.descriptors().map(|setting| setting.class_code()).collect::<Vec<_>>());
     }
 
     #[test]
     fn it_has_sub_class_code() {
-        assert_eq!(vec!(42), super::from_libusb(&interface!(interface_descriptor!(bInterfaceSubClass: 42))).descriptors().map(|setting| setting.sub_class_code()).collect::<Vec<_>>());
+        assert_eq!(vec!(42), unsafe { super::from_libusb(&interface!(interface_descriptor!(bInterfaceSubClass: 42))) }.descriptors().map(|setting| setting.sub_class_code()).collect::<Vec<_>>());
     }
 
     #[test]
     fn it_has_protocol_code() {
-        assert_eq!(vec!(42), super::from_libusb(&interface!(interface_descriptor!(bInterfaceProtocol: 42))).descriptors().map(|setting| setting.protocol_code()).collect::<Vec<_>>());
+        assert_eq!(vec!(42), unsafe { super::from_libusb(&interface!(interface_descriptor!(bInterfaceProtocol: 42))) }.descriptors().map(|setting| setting.protocol_code()).collect::<Vec<_>>());
     }
 
     #[test]
     fn it_has_description_string_index() {
-        assert_eq!(vec!(Some(42)), super::from_libusb(&interface!(interface_descriptor!(iInterface: 42))).descriptors().map(|setting| setting.description_string_index()).collect::<Vec<_>>());
+        assert_eq!(vec!(Some(42)), unsafe { super::from_libusb(&interface!(interface_descriptor!(iInterface: 42))) }.descriptors().map(|setting| setting.description_string_index()).collect::<Vec<_>>());
     }
 
     #[test]
     fn it_handles_missing_description_string_index() {
-        assert_eq!(vec!(None), super::from_libusb(&interface!(interface_descriptor!(iInterface: 0))).descriptors().map(|setting| setting.description_string_index()).collect::<Vec<_>>());
+        assert_eq!(vec!(None), unsafe { super::from_libusb(&interface!(interface_descriptor!(iInterface: 0))) }.descriptors().map(|setting| setting.description_string_index()).collect::<Vec<_>>());
     }
 
     #[test]
@@ -197,13 +197,13 @@ mod test {
         let endpoint1 = endpoint_descriptor!(bEndpointAddress: 0x81);
         let endpoint2 = endpoint_descriptor!(bEndpointAddress: 0x01);
 
-        assert_eq!(vec!(2), super::from_libusb(&interface!(interface_descriptor!(endpoint1, endpoint2))).descriptors().map(|setting| setting.num_endpoints()).collect::<Vec<_>>());
+        assert_eq!(vec!(2), unsafe { super::from_libusb(&interface!(interface_descriptor!(endpoint1, endpoint2))) }.descriptors().map(|setting| setting.num_endpoints()).collect::<Vec<_>>());
     }
 
     #[test]
     fn it_has_endpoints() {
         let libusb_interface = interface!(interface_descriptor!(endpoint_descriptor!(bEndpointAddress: 0x87)));
-        let interface = super::from_libusb(&libusb_interface);
+        let interface = unsafe { super::from_libusb(&libusb_interface) };
 
         let endpoint_addresses = interface.descriptors().next().unwrap().endpoint_descriptors().map(|endpoint| {
             endpoint.address()

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -55,7 +55,7 @@ macro_rules! interface_descriptor {
         {
             let endpoints = vec![$($endpoint),+];
 
-            ::libusb::libusb_interface_descriptor {
+            let r = ::libusb::libusb_interface_descriptor {
                 bLength:            9,
                 bDescriptorType:    0x04,
                 bInterfaceNumber:   0,
@@ -68,7 +68,11 @@ macro_rules! interface_descriptor {
                 endpoint:           (&endpoints[..]).as_ptr(),
                 extra:              $crate::test_helpers::ptr::null(),
                 extra_length:       0
-            }
+            };
+            
+            // leak the Vec so the returned pointer remains valid
+            ::std::mem::forget(endpoints);
+            r
         }
     }
 }
@@ -79,10 +83,14 @@ macro_rules! interface {
         {
             let descriptors = vec![$($descriptor),*];
 
-            ::libusb::libusb_interface {
+            let r = ::libusb::libusb_interface {
                 altsetting:     descriptors.as_ptr(),
                 num_altsetting: descriptors.len() as ::libc::c_int
-            }
+            };
+            
+            // leak the Vec so the returned pointer remains valid
+            ::std::mem::forget(descriptors);
+            r
         }
     }
 }
@@ -110,7 +118,7 @@ macro_rules! config_descriptor {
         {
             let interfaces = vec![$($interface),+];
 
-            ::libusb::libusb_config_descriptor {
+            let r = ::libusb::libusb_config_descriptor {
                 bLength:             9,
                 bDescriptorType:     0x02,
                 wTotalLength:        9,
@@ -122,7 +130,11 @@ macro_rules! config_descriptor {
                 interface:           (&interfaces[..]).as_ptr(),
                 extra:               $crate::test_helpers::ptr::null(),
                 extra_length:        0
-            }
+            };
+            
+            // leak the Vec so the returned pointer remains valid
+            ::std::mem::forget(interfaces);
+            r
         }
     }
 }


### PR DESCRIPTION
The `from_libusb` functions turn a raw pointer into a struct with safe methods and destructors that dereference the pointer. These functions are currently misused by the tests to violate memory safety in "safe" code -- the test_helpers macros return structures containing pointers to memory that was freed when the `Vec` goes out of scope within the macro.

Since there isn't a good way to move the scope of the `Vec` out to the function level besides manually expanding the macros, I made the macros simply leak the `Vec`. It may be better to reconsider the use of macros here, and construct the test data statically or in the scope of the test function.

The consequences of the use-after-free are masked by jemalloc, but show up as segfaults and in valgrind when compiled with `alloc_system:
```
==26815== Thread 2 interface_descriptor::test::it_has_sub_class_code:
==26815== Invalid read of size 1
==26815==    at 0x10001396F: libusb::interface_descriptor::InterfaceDescriptor::sub_class_code::h38a592abd132663a (interface_descriptor.rs:72)
==26815==    by 0x1000417F3: libusb::interface_descriptor::test::it_has_sub_class_code::_$u7b$$u7b$closure$u7d$$u7d$::hc5ed194dfd7e5555 (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x1000051E4: core::ops::impls::_$LT$impl$u20$core..ops..FnOnce$LT$A$GT$$u20$for$u20$$RF$$u27$a$u20$mut$u20$F$GT$::call_once::hbda3c0beb97d3534 (ops.rs:1988)
==26815==    by 0x100001F05: _$LT$core..option..Option$LT$T$GT$$GT$::map::h93c910a9c81c2638 (option.rs:385)
==26815==    by 0x1000082F0: _$LT$core..iter..Map$LT$I$C$$u20$F$GT$$u20$as$u20$core..iter..iterator..Iterator$GT$::next::h8524024f68dc0877 (mod.rs:899)
==26815==    by 0x100009423: _$LT$collections..vec..Vec$LT$T$GT$$u20$as$u20$core..iter..traits..FromIterator$LT$T$GT$$GT$::from_iter::h2c5c62bed8233cb2 (vec.rs:1346)
==26815==    by 0x100005769: core::iter::iterator::Iterator::collect::h2bc38768bba520ee (iterator.rs:1207)
==26815==    by 0x100015030: libusb::interface_descriptor::test::it_has_sub_class_code::hf6bf1e8d2b53791d (<std macros>:177)
==26815==    by 0x10004BACB: _$LT$F$u20$as$u20$alloc..boxed..FnBox$LT$A$GT$$GT$::call_box::h6c46b1f51a5f97cd (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x10006043A: test::run_test::run_test_inner::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h264d6ff770d7074c (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x1000437AD: std::panicking::try::call::h8d6a00e6c0ac8b9e (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x1000854DB: __rust_try (in target/debug/libusb-8225a624035221f7)
==26815==  Address 0x1012c4fb6 is 6 bytes inside a block of size 40 free'd
==26815==    at 0x10014D2F7: free (in /usr/local/Cellar/valgrind/3.11.0/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==26815==    by 0x100006FB4: alloc::heap::deallocate::hdab899090772cab5 (heap.rs:113)
==26815==    by 0x100007682: _$LT$alloc..raw_vec..RawVec$LT$T$GT$$u20$as$u20$core..ops..Drop$GT$::drop::h36136a8b377fd1bd (raw_vec.rs:568)
==26815==    by 0x100005EF0: drop::ha3dffa6aae84313e (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x100001958: drop_contents::hb4e29eef57f894ba (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x100005F4B: drop::hb4e29eef57f894ba (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x100014FC8: libusb::interface_descriptor::test::it_has_sub_class_code::hf6bf1e8d2b53791d (test_helpers.rs:86)
==26815==    by 0x10004BACB: _$LT$F$u20$as$u20$alloc..boxed..FnBox$LT$A$GT$$GT$::call_box::h6c46b1f51a5f97cd (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x10006043A: test::run_test::run_test_inner::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h264d6ff770d7074c (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x1000437AD: std::panicking::try::call::h8d6a00e6c0ac8b9e (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x1000854DB: __rust_try (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x100085395: __rust_maybe_catch_panic (in target/debug/libusb-8225a624035221f7)
==26815==  Block was alloc'd at
==26815==    at 0x10014CEBB: malloc (in /usr/local/Cellar/valgrind/3.11.0/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==26815==    by 0x1000070CC: alloc::heap::allocate::h252d38a38e7da6a5 (heap.rs:59)
==26815==    by 0x100007070: alloc::heap::exchange_malloc::hf72cbcfe51f02d6d (heap.rs:137)
==26815==    by 0x100014DF1: libusb::interface_descriptor::test::it_has_sub_class_code::hf6bf1e8d2b53791d (<std macros>:3)
==26815==    by 0x10004BACB: _$LT$F$u20$as$u20$alloc..boxed..FnBox$LT$A$GT$$GT$::call_box::h6c46b1f51a5f97cd (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x10006043A: test::run_test::run_test_inner::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h264d6ff770d7074c (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x1000437AD: std::panicking::try::call::h8d6a00e6c0ac8b9e (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x1000854DB: __rust_try (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x100085395: __rust_maybe_catch_panic (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x10005E185: std::thread::Builder::spawn::_$u7b$$u7b$closure$u7d$$u7d$::h9e5d89388555e457 (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x10004B878: _$LT$F$u20$as$u20$alloc..boxed..FnBox$LT$A$GT$$GT$::call_box::h173484225f9723d2 (in target/debug/libusb-8225a624035221f7)
==26815==    by 0x1000832A8: std::sys::thread::Thread::new::thread_start::h8f3bd45211e9f5ea (in target/debug/libusb-8225a624035221f7)
==26815== 
```