### PR TITLE
Update read_device.rs USAGE

### DIFF
--- a/examples/read_device.rs
+++ b/examples/read_device.rs
@@ -16,7 +16,7 @@ fn main() {
     let args: Vec<String> = std::env::args().collect();
 
     if args.len() < 3 {
-        println!("usage: show_device <vendor-id> <product-id>");
+        println!("usage: read_device <vendor-id-in-base-10> <product-id-in-base-10>");
         return;
     }
 


### PR DESCRIPTION
Fixed the name and in lieu of changing the simple id parsing logic, just documented that vendor and product id need to be in base 10.
