### PR TITLE
Add clear halt functionality

### DIFF
--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -65,6 +65,12 @@ impl<'a> DeviceHandle<'a> {
         Ok(())
     }
 
+    /// Clear the halt/stall condition for an endpoint.
+    pub fn clear_halt(&mut self, endpoint: u8) -> ::Result<()> {
+        try_unsafe!(libusb_clear_halt(self.handle, endpoint as c_uchar));
+        Ok(())
+    }
+
     /// Indicates whether the device has an attached kernel driver.
     ///
     /// This method is not supported on all platforms.


### PR DESCRIPTION
This PR adds the ability to call [libusb_clear_halt(...)](http://libusb.org/static/api-1.0/group__dev.html#ga5b321176ce7f18cfec369dd3ab7d431e) which is a necessary call in certain cases.