### PR TITLE
Don't return error on timeout when transferred > 0

### DIFF
--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -247,7 +247,7 @@ impl<'a> DeviceHandle<'a> {
                 Ok(transferred as usize)
             },
             err => {
-                if err == LIBUSB_ERROR_INTERRUPTED && transferred > 0 {
+                if (err == LIBUSB_ERROR_INTERRUPTED || err == LIBUSB_ERROR_TIMEOUT) && transferred > 0 {
                     Ok(transferred as usize)
                 }
                 else {
@@ -293,7 +293,7 @@ impl<'a> DeviceHandle<'a> {
                 Ok(transferred as usize)
             },
             err => {
-                if err == LIBUSB_ERROR_INTERRUPTED && transferred > 0 {
+                if (err == LIBUSB_ERROR_INTERRUPTED || err == LIBUSB_ERROR_TIMEOUT) && transferred > 0 {
                     Ok(transferred as usize)
                 }
                 else {


### PR DESCRIPTION
Without this fix there is no way to figure out how many bytes transferred if the call interrupted by timeout.

Excerpt from `libusb_bulk_transfer` documentation:
> **Returns**
>     0 on success (and populates transferred)
>     LIBUSB_ERROR_TIMEOUT if the transfer timed out (and populates transferred)