### PR TITLE
Run through rustfmt, update to Rust 2018, rework to use Arc instead of lifetimes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "libusb"
 version = "0.3.0"
+edition = "2018"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>"]
 description = "Rust library for accessing USB devices."
 license = "MIT"

--- a/examples/libusb_info.rs
+++ b/examples/libusb_info.rs
@@ -3,11 +3,18 @@ extern crate libusb;
 fn main() {
     let version = libusb::version();
 
-    println!("libusb v{}.{}.{}.{}{}", version.major(), version.minor(), version.micro(), version.nano(), version.rc().unwrap_or(""));
+    println!(
+        "libusb v{}.{}.{}.{}{}",
+        version.major(),
+        version.minor(),
+        version.micro(),
+        version.nano(),
+        version.rc().unwrap_or("")
+    );
 
     let mut context = match libusb::Context::new() {
         Ok(c) => c,
-        Err(e) => panic!("libusb::Context::new(): {}", e)
+        Err(e) => panic!("libusb::Context::new(): {}", e),
     };
 
     context.set_log_level(libusb::LogLevel::Debug);
@@ -19,5 +26,8 @@ fn main() {
     println!("has capability? {}", context.has_capability());
     println!("has hotplug? {}", context.has_hotplug());
     println!("has HID access? {}", context.has_hid_access());
-    println!("supports detach kernel driver? {}", context.supports_detach_kernel_driver())
+    println!(
+        "supports detach kernel driver? {}",
+        context.supports_detach_kernel_driver()
+    )
 }

--- a/examples/libusb_info.rs
+++ b/examples/libusb_info.rs
@@ -3,18 +3,11 @@ extern crate libusb;
 fn main() {
     let version = libusb::version();
 
-    println!(
-        "libusb v{}.{}.{}.{}{}",
-        version.major(),
-        version.minor(),
-        version.micro(),
-        version.nano(),
-        version.rc().unwrap_or("")
-    );
+    println!("libusb v{}.{}.{}.{}{}", version.major(), version.minor(), version.micro(), version.nano(), version.rc().unwrap_or(""));
 
     let mut context = match libusb::Context::new() {
         Ok(c) => c,
-        Err(e) => panic!("libusb::Context::new(): {}", e),
+        Err(e) => panic!("libusb::Context::new(): {}", e)
     };
 
     context.set_log_level(libusb::LogLevel::Debug);
@@ -26,8 +19,5 @@ fn main() {
     println!("has capability? {}", context.has_capability());
     println!("has hotplug? {}", context.has_hotplug());
     println!("has HID access? {}", context.has_hid_access());
-    println!(
-        "supports detach kernel driver? {}",
-        context.supports_detach_kernel_driver()
-    )
+    println!("supports detach kernel driver? {}", context.supports_detach_kernel_driver())
 }

--- a/examples/list_devices.rs
+++ b/examples/list_devices.rs
@@ -2,8 +2,8 @@ extern crate libusb;
 
 use std::time::Duration;
 
-struct UsbDevice<'a> {
-    handle: libusb::DeviceHandle<'a>,
+struct UsbDevice {
+    handle: libusb::DeviceHandle,
     language: libusb::Language,
     timeout: Duration,
 }

--- a/examples/list_devices.rs
+++ b/examples/list_devices.rs
@@ -5,9 +5,8 @@ use std::time::Duration;
 struct UsbDevice<'a> {
     handle: libusb::DeviceHandle<'a>,
     language: libusb::Language,
-    timeout: Duration
+    timeout: Duration,
 }
-
 
 fn main() {
     list_devices().unwrap();
@@ -21,39 +20,43 @@ fn list_devices() -> libusb::Result<()> {
     for device in try!(context.devices()).iter() {
         let device_desc = match device.device_descriptor() {
             Ok(d) => d,
-            Err(_) => continue
+            Err(_) => continue,
         };
 
         let mut usb_device = {
             match device.open() {
-                Ok(h) => {
-                    match h.read_languages(timeout) {
-                        Ok(l) => {
-                            if l.len() > 0 {
-                                Some(UsbDevice {
-                                    handle: h,
-                                    language: l[0],
-                                    timeout: timeout
-                                })
-                            }
-                            else {
-                                None
-                            }
-                        },
-                        Err(_) => None
+                Ok(h) => match h.read_languages(timeout) {
+                    Ok(l) => {
+                        if l.len() > 0 {
+                            Some(UsbDevice {
+                                handle: h,
+                                language: l[0],
+                                timeout: timeout,
+                            })
+                        } else {
+                            None
+                        }
                     }
+                    Err(_) => None,
                 },
-                Err(_) => None
+                Err(_) => None,
             }
         };
 
-        println!("Bus {:03} Device {:03} ID {:04x}:{:04x} {}", device.bus_number(), device.address(), device_desc.vendor_id(), device_desc.product_id(), get_speed(device.speed()));
+        println!(
+            "Bus {:03} Device {:03} ID {:04x}:{:04x} {}",
+            device.bus_number(),
+            device.address(),
+            device_desc.vendor_id(),
+            device_desc.product_id(),
+            get_speed(device.speed())
+        );
         print_device(&device_desc, &mut usb_device);
 
         for n in 0..device_desc.num_configurations() {
             let config_desc = match device.config_descriptor(n) {
                 Ok(c) => c,
-                Err(_) => continue
+                Err(_) => continue,
             };
 
             print_config(&config_desc, &mut usb_device);
@@ -75,33 +78,72 @@ fn list_devices() -> libusb::Result<()> {
 
 fn print_device(device_desc: &libusb::DeviceDescriptor, handle: &mut Option<UsbDevice>) {
     println!("Device Descriptor:");
-    println!("  bcdUSB             {:2}.{}{}", device_desc.usb_version().major(), device_desc.usb_version().minor(), device_desc.usb_version().sub_minor());
+    println!(
+        "  bcdUSB             {:2}.{}{}",
+        device_desc.usb_version().major(),
+        device_desc.usb_version().minor(),
+        device_desc.usb_version().sub_minor()
+    );
     println!("  bDeviceClass        {:#04x}", device_desc.class_code());
-    println!("  bDeviceSubClass     {:#04x}", device_desc.sub_class_code());
+    println!(
+        "  bDeviceSubClass     {:#04x}",
+        device_desc.sub_class_code()
+    );
     println!("  bDeviceProtocol     {:#04x}", device_desc.protocol_code());
     println!("  bMaxPacketSize0      {:3}", device_desc.max_packet_size());
     println!("  idVendor          {:#06x}", device_desc.vendor_id());
     println!("  idProduct         {:#06x}", device_desc.product_id());
-    println!("  bcdDevice          {:2}.{}{}", device_desc.device_version().major(), device_desc.device_version().minor(), device_desc.device_version().sub_minor());
-    println!("  iManufacturer        {:3} {}",
-             device_desc.manufacturer_string_index().unwrap_or(0),
-             handle.as_mut().map_or(String::new(), |h| h.handle.read_manufacturer_string(h.language, device_desc, h.timeout).unwrap_or(String::new())));
-    println!("  iProduct             {:3} {}",
-             device_desc.product_string_index().unwrap_or(0),
-             handle.as_mut().map_or(String::new(), |h| h.handle.read_product_string(h.language, device_desc, h.timeout).unwrap_or(String::new())));
-    println!("  iSerialNumber        {:3} {}",
-             device_desc.serial_number_string_index().unwrap_or(0),
-             handle.as_mut().map_or(String::new(), |h| h.handle.read_serial_number_string(h.language, device_desc, h.timeout).unwrap_or(String::new())));
-    println!("  bNumConfigurations   {:3}", device_desc.num_configurations());
+    println!(
+        "  bcdDevice          {:2}.{}{}",
+        device_desc.device_version().major(),
+        device_desc.device_version().minor(),
+        device_desc.device_version().sub_minor()
+    );
+    println!(
+        "  iManufacturer        {:3} {}",
+        device_desc.manufacturer_string_index().unwrap_or(0),
+        handle.as_mut().map_or(String::new(), |h| h
+            .handle
+            .read_manufacturer_string(h.language, device_desc, h.timeout)
+            .unwrap_or(String::new()))
+    );
+    println!(
+        "  iProduct             {:3} {}",
+        device_desc.product_string_index().unwrap_or(0),
+        handle.as_mut().map_or(String::new(), |h| h
+            .handle
+            .read_product_string(h.language, device_desc, h.timeout)
+            .unwrap_or(String::new()))
+    );
+    println!(
+        "  iSerialNumber        {:3} {}",
+        device_desc.serial_number_string_index().unwrap_or(0),
+        handle.as_mut().map_or(String::new(), |h| h
+            .handle
+            .read_serial_number_string(h.language, device_desc, h.timeout)
+            .unwrap_or(String::new()))
+    );
+    println!(
+        "  bNumConfigurations   {:3}",
+        device_desc.num_configurations()
+    );
 }
 
 fn print_config(config_desc: &libusb::ConfigDescriptor, handle: &mut Option<UsbDevice>) {
     println!("  Config Descriptor:");
-    println!("    bNumInterfaces       {:3}", config_desc.num_interfaces());
+    println!(
+        "    bNumInterfaces       {:3}",
+        config_desc.num_interfaces()
+    );
     println!("    bConfigurationValue  {:3}", config_desc.number());
-    println!("    iConfiguration       {:3} {}",
-             config_desc.description_string_index().unwrap_or(0),
-             handle.as_mut().map_or(String::new(), |h| h.handle.read_configuration_string(h.language, config_desc, h.timeout).unwrap_or(String::new())));
+    println!(
+        "    iConfiguration       {:3} {}",
+        config_desc.description_string_index().unwrap_or(0),
+        handle.as_mut().map_or(String::new(), |h| h
+            .handle
+            .read_configuration_string(h.language, config_desc, h.timeout)
+            .unwrap_or(String::new()))
+    );
     println!("    bmAttributes:");
     println!("      Self Powered     {:>5}", config_desc.self_powered());
     println!("      Remote Wakeup    {:>5}", config_desc.remote_wakeup());
@@ -110,34 +152,77 @@ fn print_config(config_desc: &libusb::ConfigDescriptor, handle: &mut Option<UsbD
 
 fn print_interface(interface_desc: &libusb::InterfaceDescriptor, handle: &mut Option<UsbDevice>) {
     println!("    Interface Descriptor:");
-    println!("      bInterfaceNumber     {:3}", interface_desc.interface_number());
-    println!("      bAlternateSetting    {:3}", interface_desc.setting_number());
-    println!("      bNumEndpoints        {:3}", interface_desc.num_endpoints());
-    println!("      bInterfaceClass     {:#04x}", interface_desc.class_code());
-    println!("      bInterfaceSubClass  {:#04x}", interface_desc.sub_class_code());
-    println!("      bInterfaceProtocol  {:#04x}", interface_desc.protocol_code());
-    println!("      iInterface           {:3} {}",
-             interface_desc.description_string_index().unwrap_or(0),
-             handle.as_mut().map_or(String::new(), |h| h.handle.read_interface_string(h.language, interface_desc, h.timeout).unwrap_or(String::new())));
+    println!(
+        "      bInterfaceNumber     {:3}",
+        interface_desc.interface_number()
+    );
+    println!(
+        "      bAlternateSetting    {:3}",
+        interface_desc.setting_number()
+    );
+    println!(
+        "      bNumEndpoints        {:3}",
+        interface_desc.num_endpoints()
+    );
+    println!(
+        "      bInterfaceClass     {:#04x}",
+        interface_desc.class_code()
+    );
+    println!(
+        "      bInterfaceSubClass  {:#04x}",
+        interface_desc.sub_class_code()
+    );
+    println!(
+        "      bInterfaceProtocol  {:#04x}",
+        interface_desc.protocol_code()
+    );
+    println!(
+        "      iInterface           {:3} {}",
+        interface_desc.description_string_index().unwrap_or(0),
+        handle.as_mut().map_or(String::new(), |h| h
+            .handle
+            .read_interface_string(h.language, interface_desc, h.timeout)
+            .unwrap_or(String::new()))
+    );
 }
 
 fn print_endpoint(endpoint_desc: &libusb::EndpointDescriptor) {
     println!("      Endpoint Descriptor:");
-    println!("        bEndpointAddress    {:#04x} EP {} {:?}", endpoint_desc.address(), endpoint_desc.number(), endpoint_desc.direction());
+    println!(
+        "        bEndpointAddress    {:#04x} EP {} {:?}",
+        endpoint_desc.address(),
+        endpoint_desc.number(),
+        endpoint_desc.direction()
+    );
     println!("        bmAttributes:");
-    println!("          Transfer Type          {:?}", endpoint_desc.transfer_type());
-    println!("          Synch Type             {:?}", endpoint_desc.sync_type());
-    println!("          Usage Type             {:?}", endpoint_desc.usage_type());
-    println!("        wMaxPacketSize    {:#06x}", endpoint_desc.max_packet_size());
-    println!("        bInterval            {:3}", endpoint_desc.interval());
+    println!(
+        "          Transfer Type          {:?}",
+        endpoint_desc.transfer_type()
+    );
+    println!(
+        "          Synch Type             {:?}",
+        endpoint_desc.sync_type()
+    );
+    println!(
+        "          Usage Type             {:?}",
+        endpoint_desc.usage_type()
+    );
+    println!(
+        "        wMaxPacketSize    {:#06x}",
+        endpoint_desc.max_packet_size()
+    );
+    println!(
+        "        bInterval            {:3}",
+        endpoint_desc.interval()
+    );
 }
 
 fn get_speed(speed: libusb::Speed) -> &'static str {
     match speed {
-        libusb::Speed::Super   => "5000 Mbps",
-        libusb::Speed::High    => " 480 Mbps",
-        libusb::Speed::Full    => "  12 Mbps",
-        libusb::Speed::Low     => " 1.5 Mbps",
-        libusb::Speed::Unknown => "(unknown)"
+        libusb::Speed::Super => "5000 Mbps",
+        libusb::Speed::High => " 480 Mbps",
+        libusb::Speed::Full => "  12 Mbps",
+        libusb::Speed::Low => " 1.5 Mbps",
+        libusb::Speed::Unknown => "(unknown)",
     }
 }

--- a/examples/list_devices.rs
+++ b/examples/list_devices.rs
@@ -15,9 +15,9 @@ fn main() {
 fn list_devices() -> libusb::Result<()> {
     let timeout = Duration::from_secs(1);
 
-    let context = try!(libusb::Context::new());
+    let context = libusb::Context::new()?;
 
-    for device in try!(context.devices()).iter() {
+    for device in context.devices()?.iter() {
         let device_desc = match device.device_descriptor() {
             Ok(d) => d,
             Err(_) => continue,

--- a/examples/read_device.rs
+++ b/examples/read_device.rs
@@ -9,7 +9,7 @@ struct Endpoint {
     config: u8,
     iface: u8,
     setting: u8,
-    address: u8
+    address: u8,
 }
 
 fn main() {
@@ -24,32 +24,40 @@ fn main() {
     let pid: u16 = FromStr::from_str(args[2].as_ref()).unwrap();
 
     match libusb::Context::new() {
-        Ok(mut context) => {
-            match open_device(&mut context, vid, pid) {
-                Some((mut device, device_desc, mut handle)) => read_device(&mut device, &device_desc, &mut handle).unwrap(),
-                None => println!("could not find device {:04x}:{:04x}", vid, pid)
+        Ok(mut context) => match open_device(&mut context, vid, pid) {
+            Some((mut device, device_desc, mut handle)) => {
+                read_device(&mut device, &device_desc, &mut handle).unwrap()
             }
+            None => println!("could not find device {:04x}:{:04x}", vid, pid),
         },
-        Err(e) => panic!("could not initialize libusb: {}", e)
+        Err(e) => panic!("could not initialize libusb: {}", e),
     }
 }
 
-fn open_device(context: &mut libusb::Context, vid: u16, pid: u16) -> Option<(libusb::Device, libusb::DeviceDescriptor, libusb::DeviceHandle)> {
+fn open_device(
+    context: &mut libusb::Context,
+    vid: u16,
+    pid: u16,
+) -> Option<(
+    libusb::Device,
+    libusb::DeviceDescriptor,
+    libusb::DeviceHandle,
+)> {
     let devices = match context.devices() {
         Ok(d) => d,
-        Err(_) => return None
+        Err(_) => return None,
     };
 
     for device in devices.iter() {
         let device_desc = match device.device_descriptor() {
             Ok(d) => d,
-            Err(_) => continue
+            Err(_) => continue,
         };
 
         if device_desc.vendor_id() == vid && device_desc.product_id() == pid {
             match device.open() {
                 Ok(handle) => return Some((device, device_desc, handle)),
-                Err(_) => continue
+                Err(_) => continue,
             }
         }
     }
@@ -57,52 +65,80 @@ fn open_device(context: &mut libusb::Context, vid: u16, pid: u16) -> Option<(lib
     None
 }
 
-fn read_device(device: &mut libusb::Device, device_desc: &libusb::DeviceDescriptor, handle: &mut libusb::DeviceHandle) -> libusb::Result<()> {
+fn read_device(
+    device: &mut libusb::Device,
+    device_desc: &libusb::DeviceDescriptor,
+    handle: &mut libusb::DeviceHandle,
+) -> libusb::Result<()> {
     try!(handle.reset());
 
     let timeout = Duration::from_secs(1);
     let languages = try!(handle.read_languages(timeout));
 
-    println!("Active configuration: {}", try!(handle.active_configuration()));
+    println!(
+        "Active configuration: {}",
+        try!(handle.active_configuration())
+    );
     println!("Languages: {:?}", languages);
 
     if languages.len() > 0 {
         let language = languages[0];
 
-        println!("Manufacturer: {:?}", handle.read_manufacturer_string(language, device_desc, timeout).ok());
-        println!("Product: {:?}", handle.read_product_string(language, device_desc, timeout).ok());
-        println!("Serial Number: {:?}", handle.read_serial_number_string(language, device_desc, timeout).ok());
+        println!(
+            "Manufacturer: {:?}",
+            handle
+                .read_manufacturer_string(language, device_desc, timeout)
+                .ok()
+        );
+        println!(
+            "Product: {:?}",
+            handle
+                .read_product_string(language, device_desc, timeout)
+                .ok()
+        );
+        println!(
+            "Serial Number: {:?}",
+            handle
+                .read_serial_number_string(language, device_desc, timeout)
+                .ok()
+        );
     }
 
     match find_readable_endpoint(device, device_desc, libusb::TransferType::Interrupt) {
         Some(endpoint) => read_endpoint(handle, endpoint, libusb::TransferType::Interrupt),
-        None => println!("No readable interrupt endpoint")
+        None => println!("No readable interrupt endpoint"),
     }
 
     match find_readable_endpoint(device, device_desc, libusb::TransferType::Bulk) {
         Some(endpoint) => read_endpoint(handle, endpoint, libusb::TransferType::Bulk),
-        None => println!("No readable bulk endpoint")
+        None => println!("No readable bulk endpoint"),
     }
 
     Ok(())
 }
 
-fn find_readable_endpoint(device: &mut libusb::Device, device_desc: &libusb::DeviceDescriptor, transfer_type: libusb::TransferType) -> Option<Endpoint> {
+fn find_readable_endpoint(
+    device: &mut libusb::Device,
+    device_desc: &libusb::DeviceDescriptor,
+    transfer_type: libusb::TransferType,
+) -> Option<Endpoint> {
     for n in 0..device_desc.num_configurations() {
         let config_desc = match device.config_descriptor(n) {
             Ok(c) => c,
-            Err(_) => continue
+            Err(_) => continue,
         };
 
         for interface in config_desc.interfaces() {
             for interface_desc in interface.descriptors() {
                 for endpoint_desc in interface_desc.endpoint_descriptors() {
-                    if endpoint_desc.direction() == libusb::Direction::In && endpoint_desc.transfer_type() == transfer_type {
+                    if endpoint_desc.direction() == libusb::Direction::In
+                        && endpoint_desc.transfer_type() == transfer_type
+                    {
                         return Some(Endpoint {
                             config: config_desc.number(),
                             iface: interface_desc.interface_number(),
                             setting: interface_desc.setting_number(),
-                            address: endpoint_desc.address()
+                            address: endpoint_desc.address(),
                         });
                     }
                 }
@@ -113,15 +149,19 @@ fn find_readable_endpoint(device: &mut libusb::Device, device_desc: &libusb::Dev
     None
 }
 
-fn read_endpoint(handle: &mut libusb::DeviceHandle, endpoint: Endpoint, transfer_type: libusb::TransferType) {
+fn read_endpoint(
+    handle: &mut libusb::DeviceHandle,
+    endpoint: Endpoint,
+    transfer_type: libusb::TransferType,
+) {
     println!("Reading from endpoint: {:?}", endpoint);
 
     let has_kernel_driver = match handle.kernel_driver_active(endpoint.iface) {
         Ok(true) => {
             handle.detach_kernel_driver(endpoint.iface).ok();
             true
-        },
-        _ => false
+        }
+        _ => false,
     };
 
     println!(" - kernel driver? {}", has_kernel_driver);
@@ -129,7 +169,8 @@ fn read_endpoint(handle: &mut libusb::DeviceHandle, endpoint: Endpoint, transfer
     match configure_endpoint(handle, &endpoint) {
         Ok(_) => {
             let mut vec = Vec::<u8>::with_capacity(256);
-            let mut buf = unsafe { slice::from_raw_parts_mut((&mut vec[..]).as_mut_ptr(), vec.capacity()) };
+            let mut buf =
+                unsafe { slice::from_raw_parts_mut((&mut vec[..]).as_mut_ptr(), vec.capacity()) };
 
             let timeout = Duration::from_secs(1);
 
@@ -139,23 +180,23 @@ fn read_endpoint(handle: &mut libusb::DeviceHandle, endpoint: Endpoint, transfer
                         Ok(len) => {
                             unsafe { vec.set_len(len) };
                             println!(" - read: {:?}", vec);
-                        },
-                        Err(err) => println!("could not read from endpoint: {}", err)
+                        }
+                        Err(err) => println!("could not read from endpoint: {}", err),
                     }
-                },
+                }
                 libusb::TransferType::Bulk => {
                     match handle.read_bulk(endpoint.address, buf, timeout) {
                         Ok(len) => {
                             unsafe { vec.set_len(len) };
                             println!(" - read: {:?}", vec);
-                        },
-                        Err(err) => println!("could not read from endpoint: {}", err)
+                        }
+                        Err(err) => println!("could not read from endpoint: {}", err),
                     }
-                },
-                _ => ()
+                }
+                _ => (),
             }
-        },
-        Err(err) => println!("could not configure endpoint: {}", err)
+        }
+        Err(err) => println!("could not configure endpoint: {}", err),
     }
 
     if has_kernel_driver {
@@ -163,7 +204,10 @@ fn read_endpoint(handle: &mut libusb::DeviceHandle, endpoint: Endpoint, transfer
     }
 }
 
-fn configure_endpoint<'a>(handle: &'a mut libusb::DeviceHandle, endpoint: &Endpoint) -> libusb::Result<()> {
+fn configure_endpoint<'a>(
+    handle: &'a mut libusb::DeviceHandle,
+    endpoint: &Endpoint,
+) -> libusb::Result<()> {
     try!(handle.set_active_configuration(endpoint.config));
     try!(handle.claim_interface(endpoint.iface));
     try!(handle.set_alternate_setting(endpoint.iface, endpoint.setting));

--- a/examples/read_device.rs
+++ b/examples/read_device.rs
@@ -70,15 +70,12 @@ fn read_device(
     device_desc: &libusb::DeviceDescriptor,
     handle: &mut libusb::DeviceHandle,
 ) -> libusb::Result<()> {
-    try!(handle.reset());
+    handle.reset()?;
 
     let timeout = Duration::from_secs(1);
-    let languages = try!(handle.read_languages(timeout));
+    let languages = handle.read_languages(timeout)?;
 
-    println!(
-        "Active configuration: {}",
-        try!(handle.active_configuration())
-    );
+    println!("Active configuration: {}", handle.active_configuration()?);
     println!("Languages: {:?}", languages);
 
     if languages.len() > 0 {
@@ -169,7 +166,7 @@ fn read_endpoint(
     match configure_endpoint(handle, &endpoint) {
         Ok(_) => {
             let mut vec = Vec::<u8>::with_capacity(256);
-            let mut buf =
+            let buf =
                 unsafe { slice::from_raw_parts_mut((&mut vec[..]).as_mut_ptr(), vec.capacity()) };
 
             let timeout = Duration::from_secs(1);
@@ -208,8 +205,8 @@ fn configure_endpoint<'a>(
     handle: &'a mut libusb::DeviceHandle,
     endpoint: &Endpoint,
 ) -> libusb::Result<()> {
-    try!(handle.set_active_configuration(endpoint.config));
-    try!(handle.claim_interface(endpoint.iface));
-    try!(handle.set_alternate_setting(endpoint.iface, endpoint.setting));
+    handle.set_active_configuration(endpoint.config)?;
+    handle.claim_interface(endpoint.iface)?;
+    handle.set_alternate_setting(endpoint.iface, endpoint.setting)?;
     Ok(())
 }

--- a/examples/read_device.rs
+++ b/examples/read_device.rs
@@ -24,7 +24,7 @@ fn main() {
     let pid: u16 = FromStr::from_str(args[2].as_ref()).unwrap();
 
     match libusb::Context::new() {
-        Ok(mut context) => match open_device(&mut context, vid, pid) {
+        Ok(context) => match open_device(context, vid, pid) {
             Some((mut device, device_desc, mut handle)) => {
                 read_device(&mut device, &device_desc, &mut handle).unwrap()
             }
@@ -35,7 +35,7 @@ fn main() {
 }
 
 fn open_device(
-    context: &mut libusb::Context,
+    context: libusb::Context,
     vid: u16,
     pid: u16,
 ) -> Option<(

--- a/src/config_descriptor.rs
+++ b/src/config_descriptor.rs
@@ -25,30 +25,22 @@ unsafe impl Send for ConfigDescriptor {}
 impl ConfigDescriptor {
     /// Returns the configuration number.
     pub fn number(&self) -> u8 {
-        unsafe {
-            (*self.descriptor).bConfigurationValue
-        }
+        unsafe { (*self.descriptor).bConfigurationValue }
     }
 
     /// Returns the device's maximum power consumption (in milliwatts) in this configuration.
     pub fn max_power(&self) -> u16 {
-        unsafe {
-            (*self.descriptor).bMaxPower as u16 * 2
-        }
+        unsafe { (*self.descriptor).bMaxPower as u16 * 2 }
     }
 
     /// Indicates if the device is self-powered in this configuration.
     pub fn self_powered(&self) -> bool {
-        unsafe {
-            (*self.descriptor).bmAttributes & 0x40 != 0
-        }
+        unsafe { (*self.descriptor).bmAttributes & 0x40 != 0 }
     }
 
     /// Indicates if the device has remote wakeup capability in this configuration.
     pub fn remote_wakeup(&self) -> bool {
-        unsafe {
-            (*self.descriptor).bmAttributes & 0x20 != 0
-        }
+        unsafe { (*self.descriptor).bmAttributes & 0x20 != 0 }
     }
 
     /// Returns the index of the string descriptor that describes the configuration.
@@ -63,9 +55,7 @@ impl ConfigDescriptor {
 
     /// Returns the number of interfaces for this configuration.
     pub fn num_interfaces(&self) -> u8 {
-        unsafe {
-            (*self.descriptor).bNumInterfaces
-        }
+        unsafe { (*self.descriptor).bNumInterfaces }
     }
 
     /// Returns a collection of the configuration's interfaces.
@@ -73,11 +63,13 @@ impl ConfigDescriptor {
         let interfaces = unsafe {
             slice::from_raw_parts(
                 (*self.descriptor).interface,
-                (*self.descriptor).bNumInterfaces as usize
+                (*self.descriptor).bNumInterfaces as usize,
             )
         };
 
-        Interfaces { iter: interfaces.iter() }
+        Interfaces {
+            iter: interfaces.iter(),
+        }
     }
 }
 
@@ -85,9 +77,7 @@ impl fmt::Debug for ConfigDescriptor {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let mut debug = fmt.debug_struct("ConfigDescriptor");
 
-        let descriptor: &libusb_config_descriptor = unsafe {
-            mem::transmute(self.descriptor)
-        };
+        let descriptor: &libusb_config_descriptor = unsafe { mem::transmute(self.descriptor) };
 
         debug.field("bLength", &descriptor.bLength);
         debug.field("bDescriptorType", &descriptor.bDescriptorType);
@@ -111,9 +101,9 @@ impl<'a> Iterator for Interfaces<'a> {
     type Item = Interface<'a>;
 
     fn next(&mut self) -> Option<Interface<'a>> {
-        self.iter.next().map(|interface| {
-            unsafe { interface_descriptor::from_libusb(interface) }
-        })
+        self.iter
+            .next()
+            .map(|interface| unsafe { interface_descriptor::from_libusb(interface) })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -121,12 +111,10 @@ impl<'a> Iterator for Interfaces<'a> {
     }
 }
 
-
 #[doc(hidden)]
 pub unsafe fn from_libusb(config: *const libusb_config_descriptor) -> ConfigDescriptor {
     ConfigDescriptor { descriptor: config }
 }
-
 
 #[cfg(test)]
 mod test {
@@ -139,13 +127,11 @@ mod test {
     // use mem::forget() to prevent the Drop trait impl from running. The config descriptor passed
     // as `$config` should be stack-allocated to prevent memory leaks in the test suite.
     macro_rules! with_config {
-        ($name:ident : $config:expr => $body:block) => {
-            {
-                let $name = unsafe { super::from_libusb(&$config) };
-                $body;
-                mem::forget($name);
-            }
-        }
+        ($name:ident : $config:expr => $body:block) => {{
+            let $name = unsafe { super::from_libusb(&$config) };
+            $body;
+            mem::forget($name);
+        }};
     }
 
     #[test]

--- a/src/config_descriptor.rs
+++ b/src/config_descriptor.rs
@@ -4,7 +4,7 @@ use std::slice;
 
 use libusb::*;
 
-use interface_descriptor::{self, Interface};
+use crate::interface_descriptor::{self, Interface};
 
 /// Describes a configuration.
 pub struct ConfigDescriptor {

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,9 +4,9 @@ use std::mem;
 use libc::c_int;
 use libusb::*;
 
-use device_handle::{self, DeviceHandle};
-use device_list::{self, DeviceList};
-use error;
+use crate::device_handle::{self, DeviceHandle};
+use crate::device_list::{self, DeviceList};
+use crate::error;
 
 /// A `libusb` context.
 pub struct Context {
@@ -27,7 +27,7 @@ unsafe impl Send for Context {}
 
 impl Context {
     /// Opens a new `libusb` context.
-    pub fn new() -> ::Result<Self> {
+    pub fn new() -> error::Result<Self> {
         let mut context = unsafe { mem::uninitialized() };
 
         try_unsafe!(libusb_init(&mut context));
@@ -62,7 +62,7 @@ impl Context {
     }
 
     /// Returns a list of the current USB devices. The context must outlive the device list.
-    pub fn devices<'a>(&'a self) -> ::Result<DeviceList<'a>> {
+    pub fn devices<'a>(&'a self) -> error::Result<DeviceList<'a>> {
         let mut list: *const *mut libusb_device = unsafe { mem::uninitialized() };
 
         let n = unsafe { libusb_get_device_list(self.context, &mut list) };

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,8 +4,8 @@ use std::mem;
 use libc::c_int;
 use libusb::*;
 
-use device_list::{self, DeviceList};
 use device_handle::{self, DeviceHandle};
+use device_list::{self, DeviceList};
 use error;
 
 /// A `libusb` context.
@@ -43,30 +43,22 @@ impl Context {
     }
 
     pub fn has_capability(&self) -> bool {
-        unsafe {
-            libusb_has_capability(LIBUSB_CAP_HAS_CAPABILITY) != 0
-        }
+        unsafe { libusb_has_capability(LIBUSB_CAP_HAS_CAPABILITY) != 0 }
     }
 
     /// Tests whether the running `libusb` library supports hotplug.
     pub fn has_hotplug(&self) -> bool {
-        unsafe {
-            libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG) != 0
-        }
+        unsafe { libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG) != 0 }
     }
 
     /// Tests whether the running `libusb` library has HID access.
     pub fn has_hid_access(&self) -> bool {
-        unsafe {
-            libusb_has_capability(LIBUSB_CAP_HAS_HID_ACCESS) != 0
-        }
+        unsafe { libusb_has_capability(LIBUSB_CAP_HAS_HID_ACCESS) != 0 }
     }
 
     /// Tests whether the running `libusb` library supports detaching the kernel driver.
     pub fn supports_detach_kernel_driver(&self) -> bool {
-        unsafe {
-            libusb_has_capability(LIBUSB_CAP_SUPPORTS_DETACH_KERNEL_DRIVER) != 0
-        }
+        unsafe { libusb_has_capability(LIBUSB_CAP_SUPPORTS_DETACH_KERNEL_DRIVER) != 0 }
     }
 
     /// Returns a list of the current USB devices. The context must outlive the device list.
@@ -77,8 +69,7 @@ impl Context {
 
         if n < 0 {
             Err(error::from_libusb(n as c_int))
-        }
-        else {
+        } else {
             Ok(unsafe { device_list::from_libusb(self, list, n as usize) })
         }
     }
@@ -91,18 +82,21 @@ impl Context {
     ///
     /// Returns a device handle for the first device found matching `vendor_id` and `product_id`.
     /// On error, or if the device could not be found, it returns `None`.
-    pub fn open_device_with_vid_pid<'a>(&'a self, vendor_id: u16, product_id: u16) -> Option<DeviceHandle<'a>> {
-        let handle = unsafe { libusb_open_device_with_vid_pid(self.context, vendor_id, product_id) };
+    pub fn open_device_with_vid_pid<'a>(
+        &'a self,
+        vendor_id: u16,
+        product_id: u16,
+    ) -> Option<DeviceHandle<'a>> {
+        let handle =
+            unsafe { libusb_open_device_with_vid_pid(self.context, vendor_id, product_id) };
 
         if handle.is_null() {
             None
-        }
-        else {
+        } else {
             Some(unsafe { device_handle::from_libusb(PhantomData, handle) })
         }
     }
 }
-
 
 /// Library logging levels.
 pub enum LogLevel {
@@ -127,11 +121,11 @@ pub enum LogLevel {
 impl LogLevel {
     fn as_c_int(&self) -> c_int {
         match *self {
-            LogLevel::None    => LIBUSB_LOG_LEVEL_NONE,
-            LogLevel::Error   => LIBUSB_LOG_LEVEL_ERROR,
+            LogLevel::None => LIBUSB_LOG_LEVEL_NONE,
+            LogLevel::Error => LIBUSB_LOG_LEVEL_ERROR,
             LogLevel::Warning => LIBUSB_LOG_LEVEL_WARNING,
-            LogLevel::Info    => LIBUSB_LOG_LEVEL_INFO,
-            LogLevel::Debug   => LIBUSB_LOG_LEVEL_DEBUG,
+            LogLevel::Info => LIBUSB_LOG_LEVEL_INFO,
+            LogLevel::Debug => LIBUSB_LOG_LEVEL_DEBUG,
         }
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,5 +1,4 @@
 use std::mem;
-use std::rc::Rc;
 
 use libusb::*;
 
@@ -12,7 +11,7 @@ use crate::fields::{self, Speed};
 
 /// A reference to a USB device.
 pub struct Device {
-    context: Rc<Context>,
+    context: Context,
     device: *mut libusb_device,
 }
 
@@ -22,8 +21,6 @@ impl Drop for Device {
         unsafe {
             libusb_unref_device(self.device);
         }
-
-        drop(&self.context);
     }
 }
 
@@ -87,16 +84,16 @@ impl Device {
 
         try_unsafe!(libusb_open(self.device, &mut handle));
 
-        Ok(unsafe { device_handle::from_libusb(Rc::clone(&self.context), handle) })
+        Ok(unsafe { device_handle::from_libusb(self.context.clone(), handle) })
     }
 }
 
 #[doc(hidden)]
-pub unsafe fn from_libusb(context: Rc<Context>, device: *mut libusb_device) -> Device {
+pub unsafe fn from_libusb(context: Context, device: *mut libusb_device) -> Device {
     libusb_ref_device(device);
 
     Device {
-        context: context.clone(),
+        context: context,
         device: device,
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -3,11 +3,12 @@ use std::mem;
 
 use libusb::*;
 
-use config_descriptor::{self, ConfigDescriptor};
-use context::Context;
-use device_descriptor::{self, DeviceDescriptor};
-use device_handle::{self, DeviceHandle};
-use fields::{self, Speed};
+use crate::config_descriptor::{self, ConfigDescriptor};
+use crate::context::Context;
+use crate::device_descriptor::{self, DeviceDescriptor};
+use crate::device_handle::{self, DeviceHandle};
+use crate::error;
+use crate::fields::{self, Speed};
 
 /// A reference to a USB device.
 pub struct Device<'a> {
@@ -29,7 +30,7 @@ unsafe impl<'a> Sync for Device<'a> {}
 
 impl<'a> Device<'a> {
     /// Reads the device descriptor.
-    pub fn device_descriptor(&self) -> ::Result<DeviceDescriptor> {
+    pub fn device_descriptor(&self) -> error::Result<DeviceDescriptor> {
         let mut descriptor: libusb_device_descriptor = unsafe { mem::uninitialized() };
 
         // since libusb 1.0.16, this function always succeeds
@@ -39,7 +40,7 @@ impl<'a> Device<'a> {
     }
 
     /// Reads a configuration descriptor.
-    pub fn config_descriptor(&self, config_index: u8) -> ::Result<ConfigDescriptor> {
+    pub fn config_descriptor(&self, config_index: u8) -> error::Result<ConfigDescriptor> {
         let mut config: *const libusb_config_descriptor = unsafe { mem::uninitialized() };
 
         try_unsafe!(libusb_get_config_descriptor(
@@ -52,7 +53,7 @@ impl<'a> Device<'a> {
     }
 
     /// Reads the configuration descriptor for the current configuration.
-    pub fn active_config_descriptor(&self) -> ::Result<ConfigDescriptor> {
+    pub fn active_config_descriptor(&self) -> error::Result<ConfigDescriptor> {
         let mut config: *const libusb_config_descriptor = unsafe { mem::uninitialized() };
 
         try_unsafe!(libusb_get_active_config_descriptor(
@@ -79,7 +80,7 @@ impl<'a> Device<'a> {
     }
 
     /// Opens the device.
-    pub fn open(&self) -> ::Result<DeviceHandle<'a>> {
+    pub fn open(&self) -> error::Result<DeviceHandle<'a>> {
         let mut handle: *mut libusb_device_handle = unsafe { mem::uninitialized() };
 
         try_unsafe!(libusb_open(self.device, &mut handle));

--- a/src/device.rs
+++ b/src/device.rs
@@ -3,12 +3,11 @@ use std::mem;
 
 use libusb::*;
 
-use context::Context;
-use device_handle::{self, DeviceHandle};
-use device_descriptor::{self, DeviceDescriptor};
 use config_descriptor::{self, ConfigDescriptor};
+use context::Context;
+use device_descriptor::{self, DeviceDescriptor};
+use device_handle::{self, DeviceHandle};
 use fields::{self, Speed};
-
 
 /// A reference to a USB device.
 pub struct Device<'a> {
@@ -43,7 +42,11 @@ impl<'a> Device<'a> {
     pub fn config_descriptor(&self, config_index: u8) -> ::Result<ConfigDescriptor> {
         let mut config: *const libusb_config_descriptor = unsafe { mem::uninitialized() };
 
-        try_unsafe!(libusb_get_config_descriptor(self.device, config_index, &mut config));
+        try_unsafe!(libusb_get_config_descriptor(
+            self.device,
+            config_index,
+            &mut config
+        ));
 
         Ok(unsafe { config_descriptor::from_libusb(config) })
     }
@@ -52,30 +55,27 @@ impl<'a> Device<'a> {
     pub fn active_config_descriptor(&self) -> ::Result<ConfigDescriptor> {
         let mut config: *const libusb_config_descriptor = unsafe { mem::uninitialized() };
 
-        try_unsafe!(libusb_get_active_config_descriptor(self.device, &mut config));
+        try_unsafe!(libusb_get_active_config_descriptor(
+            self.device,
+            &mut config
+        ));
 
         Ok(unsafe { config_descriptor::from_libusb(config) })
     }
 
     /// Returns the number of the bus that the device is connected to.
     pub fn bus_number(&self) -> u8 {
-        unsafe {
-            libusb_get_bus_number(self.device)
-        }
+        unsafe { libusb_get_bus_number(self.device) }
     }
 
     /// Returns the device's address on the bus that it's connected to.
     pub fn address(&self) -> u8 {
-        unsafe {
-            libusb_get_device_address(self.device)
-        }
+        unsafe { libusb_get_device_address(self.device) }
     }
 
     /// Returns the device's connection speed.
     pub fn speed(&self) -> Speed {
-        fields::speed_from_libusb(unsafe {
-            libusb_get_device_speed(self.device)
-        })
+        fields::speed_from_libusb(unsafe { libusb_get_device_speed(self.device) })
     }
 
     /// Opens the device.
@@ -89,7 +89,10 @@ impl<'a> Device<'a> {
 }
 
 #[doc(hidden)]
-pub unsafe fn from_libusb<'a>(context: PhantomData<&'a Context>, device: *mut libusb_device) -> Device<'a> {
+pub unsafe fn from_libusb<'a>(
+    context: PhantomData<&'a Context>,
+    device: *mut libusb_device,
+) -> Device<'a> {
     libusb_ref_device(device);
 
     Device {

--- a/src/device_descriptor.rs
+++ b/src/device_descriptor.rs
@@ -108,83 +108,127 @@ pub fn from_libusb(device: libusb_device_descriptor) -> DeviceDescriptor {
     DeviceDescriptor { descriptor: device }
 }
 
-
 #[cfg(test)]
 mod test {
     use fields::Version;
 
     #[test]
     fn it_has_usb_version() {
-        assert_eq!(Version::from_bcd(0x1234), super::from_libusb(device_descriptor!(bcdUSB: 0x1234)).usb_version());
+        assert_eq!(
+            Version::from_bcd(0x1234),
+            super::from_libusb(device_descriptor!(bcdUSB: 0x1234)).usb_version()
+        );
     }
 
     #[test]
     fn it_has_device_version() {
-        assert_eq!(Version::from_bcd(0x1234), super::from_libusb(device_descriptor!(bcdDevice: 0x1234)).device_version());
+        assert_eq!(
+            Version::from_bcd(0x1234),
+            super::from_libusb(device_descriptor!(bcdDevice: 0x1234)).device_version()
+        );
     }
 
     #[test]
     fn it_has_manufacturer_string_index() {
-        assert_eq!(Some(42), super::from_libusb(device_descriptor!(iManufacturer: 42)).manufacturer_string_index());
+        assert_eq!(
+            Some(42),
+            super::from_libusb(device_descriptor!(iManufacturer: 42)).manufacturer_string_index()
+        );
     }
 
     #[test]
     fn it_handles_missing_manufacturer_string_index() {
-        assert_eq!(None, super::from_libusb(device_descriptor!(iManufacturer: 0)).manufacturer_string_index());
+        assert_eq!(
+            None,
+            super::from_libusb(device_descriptor!(iManufacturer: 0)).manufacturer_string_index()
+        );
     }
 
     #[test]
     fn it_has_product_string_index() {
-        assert_eq!(Some(42), super::from_libusb(device_descriptor!(iProduct: 42)).product_string_index());
+        assert_eq!(
+            Some(42),
+            super::from_libusb(device_descriptor!(iProduct: 42)).product_string_index()
+        );
     }
 
     #[test]
     fn it_handles_missing_product_string_index() {
-        assert_eq!(None, super::from_libusb(device_descriptor!(iProduct: 0)).product_string_index());
+        assert_eq!(
+            None,
+            super::from_libusb(device_descriptor!(iProduct: 0)).product_string_index()
+        );
     }
 
     #[test]
     fn it_has_serial_number_string_index() {
-        assert_eq!(Some(42), super::from_libusb(device_descriptor!(iSerialNumber: 42)).serial_number_string_index());
+        assert_eq!(
+            Some(42),
+            super::from_libusb(device_descriptor!(iSerialNumber: 42)).serial_number_string_index()
+        );
     }
 
     #[test]
     fn it_handles_missing_serial_number_string_index() {
-        assert_eq!(None, super::from_libusb(device_descriptor!(iSerialNumber: 0)).serial_number_string_index());
+        assert_eq!(
+            None,
+            super::from_libusb(device_descriptor!(iSerialNumber: 0)).serial_number_string_index()
+        );
     }
 
     #[test]
     fn it_has_class_code() {
-        assert_eq!(42, super::from_libusb(device_descriptor!(bDeviceClass: 42)).class_code());
+        assert_eq!(
+            42,
+            super::from_libusb(device_descriptor!(bDeviceClass: 42)).class_code()
+        );
     }
 
     #[test]
     fn it_has_sub_class_code() {
-        assert_eq!(42, super::from_libusb(device_descriptor!(bDeviceSubClass: 42)).sub_class_code());
+        assert_eq!(
+            42,
+            super::from_libusb(device_descriptor!(bDeviceSubClass: 42)).sub_class_code()
+        );
     }
 
     #[test]
     fn it_has_protocol_code() {
-        assert_eq!(42, super::from_libusb(device_descriptor!(bDeviceProtocol: 42)).protocol_code());
+        assert_eq!(
+            42,
+            super::from_libusb(device_descriptor!(bDeviceProtocol: 42)).protocol_code()
+        );
     }
 
     #[test]
     fn it_has_vendor_id() {
-        assert_eq!(42, super::from_libusb(device_descriptor!(idVendor: 42)).vendor_id());
+        assert_eq!(
+            42,
+            super::from_libusb(device_descriptor!(idVendor: 42)).vendor_id()
+        );
     }
 
     #[test]
     fn it_has_product_id() {
-        assert_eq!(42, super::from_libusb(device_descriptor!(idProduct: 42)).product_id());
+        assert_eq!(
+            42,
+            super::from_libusb(device_descriptor!(idProduct: 42)).product_id()
+        );
     }
 
     #[test]
     fn it_has_max_packet_size() {
-        assert_eq!(42, super::from_libusb(device_descriptor!(bMaxPacketSize0: 42)).max_packet_size());
+        assert_eq!(
+            42,
+            super::from_libusb(device_descriptor!(bMaxPacketSize0: 42)).max_packet_size()
+        );
     }
 
     #[test]
     fn it_has_num_configurations() {
-        assert_eq!(3, super::from_libusb(device_descriptor!(bNumConfigurations: 3)).num_configurations());
+        assert_eq!(
+            3,
+            super::from_libusb(device_descriptor!(bNumConfigurations: 3)).num_configurations()
+        );
     }
 }

--- a/src/device_descriptor.rs
+++ b/src/device_descriptor.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use libusb::*;
 
-use fields::Version;
+use crate::fields::Version;
 
 /// Describes a device.
 pub struct DeviceDescriptor {
@@ -110,7 +110,7 @@ pub fn from_libusb(device: libusb_device_descriptor) -> DeviceDescriptor {
 
 #[cfg(test)]
 mod test {
-    use fields::Version;
+    use crate::fields::Version;
 
     #[test]
     fn it_has_usb_version() {

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -1,5 +1,4 @@
 use std::mem;
-use std::rc::Rc;
 use std::slice;
 use std::time::Duration;
 
@@ -17,7 +16,7 @@ use crate::language::{self, Language};
 
 /// A handle to an open USB device.
 pub struct DeviceHandle {
-    context: Rc<Context>,
+    _context: Context,
     handle: *mut libusb_device_handle,
     interfaces: BitSet,
 }
@@ -32,8 +31,6 @@ impl Drop for DeviceHandle {
 
             libusb_close(self.handle);
         }
-
-        drop(&self.context);
     }
 }
 
@@ -617,9 +614,9 @@ impl DeviceHandle {
 }
 
 #[doc(hidden)]
-pub unsafe fn from_libusb(context: Rc<Context>, handle: *mut libusb_device_handle) -> DeviceHandle {
+pub unsafe fn from_libusb(context: Context, handle: *mut libusb_device_handle) -> DeviceHandle {
     DeviceHandle {
-        context: context.clone(),
+        _context: context,
         handle: handle,
         interfaces: BitSet::with_capacity(u8::max_value() as usize + 1),
     }

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -476,7 +476,7 @@ impl<'a> DeviceHandle<'a> {
     pub fn read_languages(&self, timeout: Duration) -> ::Result<Vec<Language>> {
         let mut buf = Vec::<u8>::with_capacity(256);
 
-        let mut buf_slice =
+        let buf_slice =
             unsafe { slice::from_raw_parts_mut((&mut buf[..]).as_mut_ptr(), buf.capacity()) };
 
         let len = try!(self.read_control(
@@ -513,7 +513,7 @@ impl<'a> DeviceHandle<'a> {
     ) -> ::Result<String> {
         let mut buf = Vec::<u8>::with_capacity(256);
 
-        let mut buf_slice =
+        let buf_slice =
             unsafe { slice::from_raw_parts_mut((&mut buf[..]).as_mut_ptr(), buf.capacity()) };
 
         let len = try!(self.read_control(

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -4,15 +4,15 @@ use std::slice;
 use std::time::Duration;
 
 use bit_set::BitSet;
-use libc::{c_int, c_uint, c_uchar};
+use libc::{c_int, c_uchar, c_uint};
 use libusb::*;
 
-use context::Context;
-use error::{self, Error};
-use device_descriptor::DeviceDescriptor;
 use config_descriptor::ConfigDescriptor;
+use context::Context;
+use device_descriptor::DeviceDescriptor;
+use error::{self, Error};
+use fields::{request_type, Direction, Recipient, RequestType};
 use interface_descriptor::InterfaceDescriptor;
-use fields::{Direction, RequestType, Recipient, request_type};
 use language::Language;
 
 /// A handle to an open USB device.
@@ -111,7 +111,11 @@ impl<'a> DeviceHandle<'a> {
 
     /// Sets an interface's active setting.
     pub fn set_alternate_setting(&mut self, iface: u8, setting: u8) -> ::Result<()> {
-        try_unsafe!(libusb_set_interface_alt_setting(self.handle, iface as c_int, setting as c_int));
+        try_unsafe!(libusb_set_interface_alt_setting(
+            self.handle,
+            iface as c_int,
+            setting as c_int
+        ));
         Ok(())
     }
 
@@ -137,7 +141,12 @@ impl<'a> DeviceHandle<'a> {
     /// * `Overflow` if the device offered more data.
     /// * `NoDevice` if the device has been disconnected.
     /// * `Io` if the transfer encountered an I/O error.
-    pub fn read_interrupt(&self, endpoint: u8, buf: &mut [u8], timeout: Duration) -> ::Result<usize> {
+    pub fn read_interrupt(
+        &self,
+        endpoint: u8,
+        buf: &mut [u8],
+        timeout: Duration,
+    ) -> ::Result<usize> {
         if endpoint & LIBUSB_ENDPOINT_DIR_MASK != LIBUSB_ENDPOINT_IN {
             return Err(Error::InvalidParam);
         }
@@ -146,20 +155,27 @@ impl<'a> DeviceHandle<'a> {
 
         let ptr = buf.as_mut_ptr() as *mut c_uchar;
         let len = buf.len() as c_int;
-        let timeout_ms = (timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000) as c_uint;
+        let timeout_ms =
+            (timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000) as c_uint;
 
-        match unsafe { libusb_interrupt_transfer(self.handle, endpoint, ptr, len, &mut transferred, timeout_ms) } {
-            0 => {
-                Ok(transferred as usize)
-            },
+        match unsafe {
+            libusb_interrupt_transfer(
+                self.handle,
+                endpoint,
+                ptr,
+                len,
+                &mut transferred,
+                timeout_ms,
+            )
+        } {
+            0 => Ok(transferred as usize),
             err => {
                 if err == LIBUSB_ERROR_INTERRUPTED && transferred > 0 {
                     Ok(transferred as usize)
-                }
-                else {
+                } else {
                     Err(error::from_libusb(err))
                 }
-            },
+            }
         }
     }
 
@@ -192,20 +208,27 @@ impl<'a> DeviceHandle<'a> {
 
         let ptr = buf.as_ptr() as *mut c_uchar;
         let len = buf.len() as c_int;
-        let timeout_ms = (timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000) as c_uint;
+        let timeout_ms =
+            (timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000) as c_uint;
 
-        match unsafe { libusb_interrupt_transfer(self.handle, endpoint, ptr, len, &mut transferred, timeout_ms) } {
-            0 => {
-                Ok(transferred as usize)
-            },
+        match unsafe {
+            libusb_interrupt_transfer(
+                self.handle,
+                endpoint,
+                ptr,
+                len,
+                &mut transferred,
+                timeout_ms,
+            )
+        } {
+            0 => Ok(transferred as usize),
             err => {
                 if err == LIBUSB_ERROR_INTERRUPTED && transferred > 0 {
                     Ok(transferred as usize)
-                }
-                else {
+                } else {
                     Err(error::from_libusb(err))
                 }
-            },
+            }
         }
     }
 
@@ -240,20 +263,27 @@ impl<'a> DeviceHandle<'a> {
 
         let ptr = buf.as_mut_ptr() as *mut c_uchar;
         let len = buf.len() as c_int;
-        let timeout_ms = (timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000) as c_uint;
+        let timeout_ms =
+            (timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000) as c_uint;
 
-        match unsafe { libusb_bulk_transfer(self.handle, endpoint, ptr, len, &mut transferred, timeout_ms) } {
-            0 => {
-                Ok(transferred as usize)
-            },
+        match unsafe {
+            libusb_bulk_transfer(
+                self.handle,
+                endpoint,
+                ptr,
+                len,
+                &mut transferred,
+                timeout_ms,
+            )
+        } {
+            0 => Ok(transferred as usize),
             err => {
                 if err == LIBUSB_ERROR_INTERRUPTED && transferred > 0 {
                     Ok(transferred as usize)
-                }
-                else {
+                } else {
                     Err(error::from_libusb(err))
                 }
-            },
+            }
         }
     }
 
@@ -286,20 +316,27 @@ impl<'a> DeviceHandle<'a> {
 
         let ptr = buf.as_ptr() as *mut c_uchar;
         let len = buf.len() as c_int;
-        let timeout_ms = (timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000) as c_uint;
+        let timeout_ms =
+            (timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000) as c_uint;
 
-        match unsafe { libusb_bulk_transfer(self.handle, endpoint, ptr, len, &mut transferred, timeout_ms) } {
-            0 => {
-                Ok(transferred as usize)
-            },
+        match unsafe {
+            libusb_bulk_transfer(
+                self.handle,
+                endpoint,
+                ptr,
+                len,
+                &mut transferred,
+                timeout_ms,
+            )
+        } {
+            0 => Ok(transferred as usize),
             err => {
                 if err == LIBUSB_ERROR_INTERRUPTED && transferred > 0 {
                     Ok(transferred as usize)
-                }
-                else {
+                } else {
                     Err(error::from_libusb(err))
                 }
-            },
+            }
         }
     }
 
@@ -330,17 +367,35 @@ impl<'a> DeviceHandle<'a> {
     /// * `Pipe` if the control request was not supported by the device.
     /// * `NoDevice` if the device has been disconnected.
     /// * `Io` if the transfer encountered an I/O error.
-    pub fn read_control(&self, request_type: u8, request: u8, value: u16, index: u16, buf: &mut [u8], timeout: Duration) -> ::Result<usize> {
+    pub fn read_control(
+        &self,
+        request_type: u8,
+        request: u8,
+        value: u16,
+        index: u16,
+        buf: &mut [u8],
+        timeout: Duration,
+    ) -> ::Result<usize> {
         if request_type & LIBUSB_ENDPOINT_DIR_MASK != LIBUSB_ENDPOINT_IN {
             return Err(Error::InvalidParam);
         }
 
         let ptr = buf.as_mut_ptr() as *mut c_uchar;
         let len = buf.len() as u16;
-        let timeout_ms = (timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000) as c_uint;
+        let timeout_ms =
+            (timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000) as c_uint;
 
         let res = unsafe {
-            libusb_control_transfer(self.handle, request_type, request, value, index, ptr, len, timeout_ms)
+            libusb_control_transfer(
+                self.handle,
+                request_type,
+                request,
+                value,
+                index,
+                ptr,
+                len,
+                timeout_ms,
+            )
         };
 
         if res < 0 {
@@ -376,17 +431,35 @@ impl<'a> DeviceHandle<'a> {
     /// * `Pipe` if the control request was not supported by the device.
     /// * `NoDevice` if the device has been disconnected.
     /// * `Io` if the transfer encountered an I/O error.
-    pub fn write_control(&self, request_type: u8, request: u8, value: u16, index: u16, buf: &[u8], timeout: Duration) -> ::Result<usize> {
+    pub fn write_control(
+        &self,
+        request_type: u8,
+        request: u8,
+        value: u16,
+        index: u16,
+        buf: &[u8],
+        timeout: Duration,
+    ) -> ::Result<usize> {
         if request_type & LIBUSB_ENDPOINT_DIR_MASK != LIBUSB_ENDPOINT_OUT {
             return Err(Error::InvalidParam);
         }
 
         let ptr = buf.as_ptr() as *mut c_uchar;
         let len = buf.len() as u16;
-        let timeout_ms = (timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000) as c_uint;
+        let timeout_ms =
+            (timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000) as c_uint;
 
         let res = unsafe {
-            libusb_control_transfer(self.handle, request_type, request, value, index, ptr, len, timeout_ms)
+            libusb_control_transfer(
+                self.handle,
+                request_type,
+                request,
+                value,
+                index,
+                ptr,
+                len,
+                timeout_ms,
+            )
         };
 
         if res < 0 {
@@ -403,98 +476,139 @@ impl<'a> DeviceHandle<'a> {
     pub fn read_languages(&self, timeout: Duration) -> ::Result<Vec<Language>> {
         let mut buf = Vec::<u8>::with_capacity(256);
 
-        let mut buf_slice = unsafe {
-            slice::from_raw_parts_mut((&mut buf[..]).as_mut_ptr(), buf.capacity())
-        };
+        let mut buf_slice =
+            unsafe { slice::from_raw_parts_mut((&mut buf[..]).as_mut_ptr(), buf.capacity()) };
 
-        let len = try!(self.read_control(request_type(Direction::In, RequestType::Standard, Recipient::Device),
-                                         LIBUSB_REQUEST_GET_DESCRIPTOR,
-                                         (LIBUSB_DT_STRING as u16) << 8,
-                                         0,
-                                         buf_slice,
-                                         timeout));
+        let len = try!(self.read_control(
+            request_type(Direction::In, RequestType::Standard, Recipient::Device),
+            LIBUSB_REQUEST_GET_DESCRIPTOR,
+            (LIBUSB_DT_STRING as u16) << 8,
+            0,
+            buf_slice,
+            timeout
+        ));
 
         unsafe {
             buf.set_len(len);
         }
 
-        Ok(buf.chunks(2).skip(1).map(|chunk| {
-            let lang_id = chunk[0] as u16 | (chunk[1] as u16) << 8;
-            ::language::from_lang_id(lang_id)
-        }).collect())
+        Ok(buf
+            .chunks(2)
+            .skip(1)
+            .map(|chunk| {
+                let lang_id = chunk[0] as u16 | (chunk[1] as u16) << 8;
+                ::language::from_lang_id(lang_id)
+            })
+            .collect())
     }
 
     /// Reads a string descriptor from the device.
     ///
     /// `language` should be one of the languages returned from [`read_languages`](#method.read_languages).
-    pub fn read_string_descriptor(&self, language: Language, index: u8, timeout: Duration) -> ::Result<String> {
+    pub fn read_string_descriptor(
+        &self,
+        language: Language,
+        index: u8,
+        timeout: Duration,
+    ) -> ::Result<String> {
         let mut buf = Vec::<u8>::with_capacity(256);
 
-        let mut buf_slice = unsafe {
-            slice::from_raw_parts_mut((&mut buf[..]).as_mut_ptr(), buf.capacity())
-        };
+        let mut buf_slice =
+            unsafe { slice::from_raw_parts_mut((&mut buf[..]).as_mut_ptr(), buf.capacity()) };
 
-        let len = try!(self.read_control(request_type(Direction::In, RequestType::Standard, Recipient::Device),
-                                         LIBUSB_REQUEST_GET_DESCRIPTOR,
-                                         (LIBUSB_DT_STRING as u16) << 8 | index as u16,
-                                         language.lang_id(),
-                                         buf_slice,
-                                         timeout));
+        let len = try!(self.read_control(
+            request_type(Direction::In, RequestType::Standard, Recipient::Device),
+            LIBUSB_REQUEST_GET_DESCRIPTOR,
+            (LIBUSB_DT_STRING as u16) << 8 | index as u16,
+            language.lang_id(),
+            buf_slice,
+            timeout
+        ));
 
         unsafe {
             buf.set_len(len);
         }
 
-        let utf16: Vec<u16> = buf.chunks(2).skip(1).map(|chunk| {
-            chunk[0] as u16 | (chunk[1] as u16) << 8
-        }).collect();
+        let utf16: Vec<u16> = buf
+            .chunks(2)
+            .skip(1)
+            .map(|chunk| chunk[0] as u16 | (chunk[1] as u16) << 8)
+            .collect();
 
         String::from_utf16(&utf16[..]).map_err(|_| Error::Other)
     }
 
     /// Reads the device's manufacturer string descriptor.
-    pub fn read_manufacturer_string(&self, language: Language, device: &DeviceDescriptor, timeout: Duration) -> ::Result<String> {
+    pub fn read_manufacturer_string(
+        &self,
+        language: Language,
+        device: &DeviceDescriptor,
+        timeout: Duration,
+    ) -> ::Result<String> {
         match device.manufacturer_string_index() {
             None => Err(Error::InvalidParam),
-            Some(n) => self.read_string_descriptor(language, n, timeout)
+            Some(n) => self.read_string_descriptor(language, n, timeout),
         }
     }
 
     /// Reads the device's product string descriptor.
-    pub fn read_product_string(&self, language: Language, device: &DeviceDescriptor, timeout: Duration) -> ::Result<String> {
+    pub fn read_product_string(
+        &self,
+        language: Language,
+        device: &DeviceDescriptor,
+        timeout: Duration,
+    ) -> ::Result<String> {
         match device.product_string_index() {
             None => Err(Error::InvalidParam),
-            Some(n) => self.read_string_descriptor(language, n, timeout)
+            Some(n) => self.read_string_descriptor(language, n, timeout),
         }
     }
 
     /// Reads the device's serial number string descriptor.
-    pub fn read_serial_number_string(&self, language: Language, device: &DeviceDescriptor, timeout: Duration) -> ::Result<String> {
+    pub fn read_serial_number_string(
+        &self,
+        language: Language,
+        device: &DeviceDescriptor,
+        timeout: Duration,
+    ) -> ::Result<String> {
         match device.serial_number_string_index() {
             None => Err(Error::InvalidParam),
-            Some(n) => self.read_string_descriptor(language, n, timeout)
+            Some(n) => self.read_string_descriptor(language, n, timeout),
         }
     }
 
     /// Reads the string descriptor for a configuration's description.
-    pub fn read_configuration_string(&self, language: Language, configuration: &ConfigDescriptor, timeout: Duration) -> ::Result<String> {
+    pub fn read_configuration_string(
+        &self,
+        language: Language,
+        configuration: &ConfigDescriptor,
+        timeout: Duration,
+    ) -> ::Result<String> {
         match configuration.description_string_index() {
             None => Err(Error::InvalidParam),
-            Some(n) => self.read_string_descriptor(language, n, timeout)
+            Some(n) => self.read_string_descriptor(language, n, timeout),
         }
     }
 
     /// Reads the string descriptor for a interface's description.
-    pub fn read_interface_string(&self, language: Language, interface: &InterfaceDescriptor, timeout: Duration) -> ::Result<String> {
+    pub fn read_interface_string(
+        &self,
+        language: Language,
+        interface: &InterfaceDescriptor,
+        timeout: Duration,
+    ) -> ::Result<String> {
         match interface.description_string_index() {
             None => Err(Error::InvalidParam),
-            Some(n) => self.read_string_descriptor(language, n, timeout)
+            Some(n) => self.read_string_descriptor(language, n, timeout),
         }
     }
 }
 
 #[doc(hidden)]
-pub unsafe fn from_libusb<'a>(context: PhantomData<&'a Context>, handle: *mut libusb_device_handle) -> DeviceHandle<'a> {
+pub unsafe fn from_libusb<'a>(
+    context: PhantomData<&'a Context>,
+    handle: *mut libusb_device_handle,
+) -> DeviceHandle<'a> {
     DeviceHandle {
         _context: context,
         handle: handle,

--- a/src/device_list.rs
+++ b/src/device_list.rs
@@ -56,8 +56,7 @@ impl<'a, 'b> Iterator for Devices<'a, 'b> {
 
             self.index += 1;
             Some(unsafe { device::from_libusb(self.context, device) })
-        }
-        else {
+        } else {
             None
         }
     }
@@ -68,9 +67,12 @@ impl<'a, 'b> Iterator for Devices<'a, 'b> {
     }
 }
 
-
 #[doc(hidden)]
-pub unsafe fn from_libusb<'a>(_context: &'a Context, list: *const *mut libusb_device, len: usize,) -> DeviceList<'a> {
+pub unsafe fn from_libusb<'a>(
+    _context: &'a Context,
+    list: *const *mut libusb_device,
+    len: usize,
+) -> DeviceList<'a> {
     DeviceList {
         context: PhantomData,
         list: list,

--- a/src/device_list.rs
+++ b/src/device_list.rs
@@ -3,8 +3,8 @@ use std::slice;
 
 use libusb::*;
 
-use context::Context;
-use device::{self, Device};
+use crate::context::Context;
+use crate::device::{self, Device};
 
 /// A list of detected USB devices.
 pub struct DeviceList<'a> {

--- a/src/endpoint_descriptor.rs
+++ b/src/endpoint_descriptor.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use libusb::*;
 
-use fields::{Direction, TransferType, SyncType, UsageType};
+use fields::{Direction, SyncType, TransferType, UsageType};
 
 /// Describes an endpoint.
 pub struct EndpointDescriptor<'a> {
@@ -23,7 +23,7 @@ impl<'a> EndpointDescriptor<'a> {
     /// Returns the endpoint's direction.
     pub fn direction(&self) -> Direction {
         match self.descriptor.bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK {
-            LIBUSB_ENDPOINT_OUT    => Direction::Out,
+            LIBUSB_ENDPOINT_OUT => Direction::Out,
             LIBUSB_ENDPOINT_IN | _ => Direction::In,
         }
     }
@@ -31,9 +31,9 @@ impl<'a> EndpointDescriptor<'a> {
     /// Returns the endpoint's transfer type.
     pub fn transfer_type(&self) -> TransferType {
         match self.descriptor.bmAttributes & LIBUSB_TRANSFER_TYPE_MASK {
-            LIBUSB_TRANSFER_TYPE_CONTROL       => TransferType::Control,
-            LIBUSB_TRANSFER_TYPE_ISOCHRONOUS   => TransferType::Isochronous,
-            LIBUSB_TRANSFER_TYPE_BULK          => TransferType::Bulk,
+            LIBUSB_TRANSFER_TYPE_CONTROL => TransferType::Control,
+            LIBUSB_TRANSFER_TYPE_ISOCHRONOUS => TransferType::Isochronous,
+            LIBUSB_TRANSFER_TYPE_BULK => TransferType::Bulk,
             LIBUSB_TRANSFER_TYPE_INTERRUPT | _ => TransferType::Interrupt,
         }
     }
@@ -43,8 +43,8 @@ impl<'a> EndpointDescriptor<'a> {
     /// The return value of this method is only valid for isochronous endpoints.
     pub fn sync_type(&self) -> SyncType {
         match (self.descriptor.bmAttributes & LIBUSB_ISO_SYNC_TYPE_MASK) >> 2 {
-            LIBUSB_ISO_SYNC_TYPE_NONE     => SyncType::NoSync,
-            LIBUSB_ISO_SYNC_TYPE_ASYNC    => SyncType::Asynchronous,
+            LIBUSB_ISO_SYNC_TYPE_NONE => SyncType::NoSync,
+            LIBUSB_ISO_SYNC_TYPE_ASYNC => SyncType::Asynchronous,
             LIBUSB_ISO_SYNC_TYPE_ADAPTIVE => SyncType::Adaptive,
             LIBUSB_ISO_SYNC_TYPE_SYNC | _ => SyncType::Synchronous,
         }
@@ -55,10 +55,10 @@ impl<'a> EndpointDescriptor<'a> {
     /// The return value of this method is only valid for isochronous endpoints.
     pub fn usage_type(&self) -> UsageType {
         match (self.descriptor.bmAttributes & LIBUSB_ISO_USAGE_TYPE_MASK) >> 4 {
-            LIBUSB_ISO_USAGE_TYPE_DATA     => UsageType::Data,
+            LIBUSB_ISO_USAGE_TYPE_DATA => UsageType::Data,
             LIBUSB_ISO_USAGE_TYPE_FEEDBACK => UsageType::Feedback,
             LIBUSB_ISO_USAGE_TYPE_IMPLICIT => UsageType::FeedbackData,
-            _                              => UsageType::Reserved,
+            _ => UsageType::Reserved,
         }
     }
 
@@ -90,76 +90,164 @@ impl<'a> fmt::Debug for EndpointDescriptor<'a> {
 
 #[doc(hidden)]
 pub fn from_libusb(endpoint: &libusb_endpoint_descriptor) -> EndpointDescriptor {
-    EndpointDescriptor { descriptor: endpoint }
+    EndpointDescriptor {
+        descriptor: endpoint,
+    }
 }
-
 
 #[cfg(test)]
 mod test {
-    use ::fields::{Direction,TransferType,SyncType,UsageType};
+    use fields::{Direction, SyncType, TransferType, UsageType};
 
     #[test]
     fn it_interprets_number_for_output_endpoints() {
-        assert_eq!(0, super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0000_0000)).number());
-        assert_eq!(1, super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0000_0001)).number());
+        assert_eq!(
+            0,
+            super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0000_0000)).number()
+        );
+        assert_eq!(
+            1,
+            super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0000_0001)).number()
+        );
     }
 
     #[test]
     fn it_interprets_number_for_input_endpoints() {
-        assert_eq!(2, super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b1000_0010)).number());
-        assert_eq!(3, super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b1000_0011)).number());
+        assert_eq!(
+            2,
+            super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b1000_0010)).number()
+        );
+        assert_eq!(
+            3,
+            super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b1000_0011)).number()
+        );
     }
 
     #[test]
     fn it_ignores_reserved_bits_in_address() {
-        assert_eq!(0, super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0000_1000)).number());
-        assert_eq!(0, super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0001_0000)).number());
-        assert_eq!(0, super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0010_0000)).number());
-        assert_eq!(0, super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0100_0000)).number());
-        assert_eq!(7, super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b1111_1111)).number());
+        assert_eq!(
+            0,
+            super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0000_1000)).number()
+        );
+        assert_eq!(
+            0,
+            super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0001_0000)).number()
+        );
+        assert_eq!(
+            0,
+            super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0010_0000)).number()
+        );
+        assert_eq!(
+            0,
+            super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0100_0000)).number()
+        );
+        assert_eq!(
+            7,
+            super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b1111_1111)).number()
+        );
     }
 
     #[test]
     fn it_interprets_direction_bit_in_address() {
-        assert_eq!(Direction::Out, super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0000_0000)).direction());
-        assert_eq!(Direction::In,  super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b1000_0000)).direction());
+        assert_eq!(
+            Direction::Out,
+            super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b0000_0000)).direction()
+        );
+        assert_eq!(
+            Direction::In,
+            super::from_libusb(&endpoint_descriptor!(bEndpointAddress: 0b1000_0000)).direction()
+        );
     }
 
     #[test]
     fn it_interprets_transfer_type_in_attributes() {
-        assert_eq!(TransferType::Control,     super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_0000)).transfer_type());
-        assert_eq!(TransferType::Isochronous, super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_0001)).transfer_type());
-        assert_eq!(TransferType::Bulk,        super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_0010)).transfer_type());
-        assert_eq!(TransferType::Interrupt,   super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_0011)).transfer_type());
+        assert_eq!(
+            TransferType::Control,
+            super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_0000)).transfer_type()
+        );
+        assert_eq!(
+            TransferType::Isochronous,
+            super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_0001)).transfer_type()
+        );
+        assert_eq!(
+            TransferType::Bulk,
+            super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_0010)).transfer_type()
+        );
+        assert_eq!(
+            TransferType::Interrupt,
+            super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_0011)).transfer_type()
+        );
     }
 
     #[test]
     fn it_interprets_synchronization_type_in_attributes() {
-        assert_eq!(SyncType::NoSync,       super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_0001)).sync_type());
-        assert_eq!(SyncType::Asynchronous, super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_0101)).sync_type());
-        assert_eq!(SyncType::Adaptive,     super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_1001)).sync_type());
-        assert_eq!(SyncType::Synchronous,  super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_1101)).sync_type());
+        assert_eq!(
+            SyncType::NoSync,
+            super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_0001)).sync_type()
+        );
+        assert_eq!(
+            SyncType::Asynchronous,
+            super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_0101)).sync_type()
+        );
+        assert_eq!(
+            SyncType::Adaptive,
+            super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_1001)).sync_type()
+        );
+        assert_eq!(
+            SyncType::Synchronous,
+            super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_1101)).sync_type()
+        );
     }
 
     #[test]
     fn it_interprets_usage_type_in_attributes() {
-        assert_eq!(UsageType::Data,         super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_0001)).usage_type());
-        assert_eq!(UsageType::Feedback,     super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0001_0001)).usage_type());
-        assert_eq!(UsageType::FeedbackData, super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0010_0001)).usage_type());
-        assert_eq!(UsageType::Reserved,     super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0011_0001)).usage_type());
+        assert_eq!(
+            UsageType::Data,
+            super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0000_0001)).usage_type()
+        );
+        assert_eq!(
+            UsageType::Feedback,
+            super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0001_0001)).usage_type()
+        );
+        assert_eq!(
+            UsageType::FeedbackData,
+            super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0010_0001)).usage_type()
+        );
+        assert_eq!(
+            UsageType::Reserved,
+            super::from_libusb(&endpoint_descriptor!(bmAttributes: 0b0011_0001)).usage_type()
+        );
     }
 
     #[test]
     fn it_has_max_packet_size() {
-        assert_eq!(64,    super::from_libusb(&endpoint_descriptor!(wMaxPacketSize: 64)).max_packet_size());
-        assert_eq!(4096,  super::from_libusb(&endpoint_descriptor!(wMaxPacketSize: 4096)).max_packet_size());
-        assert_eq!(65535, super::from_libusb(&endpoint_descriptor!(wMaxPacketSize: 65535)).max_packet_size());
+        assert_eq!(
+            64,
+            super::from_libusb(&endpoint_descriptor!(wMaxPacketSize: 64)).max_packet_size()
+        );
+        assert_eq!(
+            4096,
+            super::from_libusb(&endpoint_descriptor!(wMaxPacketSize: 4096)).max_packet_size()
+        );
+        assert_eq!(
+            65535,
+            super::from_libusb(&endpoint_descriptor!(wMaxPacketSize: 65535)).max_packet_size()
+        );
     }
 
     #[test]
     fn it_has_interval() {
-        assert_eq!(1,   super::from_libusb(&endpoint_descriptor!(bInterval: 1)).interval());
-        assert_eq!(20,  super::from_libusb(&endpoint_descriptor!(bInterval: 20)).interval());
-        assert_eq!(255, super::from_libusb(&endpoint_descriptor!(bInterval: 255)).interval());
+        assert_eq!(
+            1,
+            super::from_libusb(&endpoint_descriptor!(bInterval: 1)).interval()
+        );
+        assert_eq!(
+            20,
+            super::from_libusb(&endpoint_descriptor!(bInterval: 20)).interval()
+        );
+        assert_eq!(
+            255,
+            super::from_libusb(&endpoint_descriptor!(bInterval: 255)).interval()
+        );
     }
 }

--- a/src/endpoint_descriptor.rs
+++ b/src/endpoint_descriptor.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use libusb::*;
 
-use fields::{Direction, SyncType, TransferType, UsageType};
+use crate::fields::{Direction, SyncType, TransferType, UsageType};
 
 /// Describes an endpoint.
 pub struct EndpointDescriptor<'a> {
@@ -97,7 +97,7 @@ pub fn from_libusb(endpoint: &libusb_endpoint_descriptor) -> EndpointDescriptor 
 
 #[cfg(test)]
 mod test {
-    use fields::{Direction, SyncType, TransferType, UsageType};
+    use crate::fields::{Direction, SyncType, TransferType, UsageType};
 
     #[test]
     fn it_interprets_number_for_output_endpoints() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use std::error::Error as StdError;
+use std::fmt;
 use std::result::Result as StdResult;
 
 use libc::c_int;
@@ -7,7 +7,6 @@ use libusb::*;
 
 /// A result of a function that may return a `Error`.
 pub type Result<T> = StdResult<T, Error>;
-
 
 /// Errors returned by the `libusb` library.
 #[derive(Debug)]
@@ -52,27 +51,27 @@ pub enum Error {
     NotSupported,
 
     /// Other error.
-    Other
+    Other,
 }
 
 impl Error {
     /// Returns a description of an error suitable for display to an end user.
     pub fn strerror(&self) -> &'static str {
         match *self {
-            Error::Success      => "Success",
-            Error::Io           => "Input/Output Error",
+            Error::Success => "Success",
+            Error::Io => "Input/Output Error",
             Error::InvalidParam => "Invalid parameter",
-            Error::Access       => "Access denied (insufficient permissions)",
-            Error::NoDevice     => "No such device (it may have been disconnected)",
-            Error::NotFound     => "Entity not found",
-            Error::Busy         => "Resource busy",
-            Error::Timeout      => "Operation timed out",
-            Error::Overflow     => "Overflow",
-            Error::Pipe         => "Pipe error",
-            Error::Interrupted  => "System call interrupted (perhaps due to signal)",
-            Error::NoMem        => "Insufficient memory",
+            Error::Access => "Access denied (insufficient permissions)",
+            Error::NoDevice => "No such device (it may have been disconnected)",
+            Error::NotFound => "Entity not found",
+            Error::Busy => "Resource busy",
+            Error::Timeout => "Operation timed out",
+            Error::Overflow => "Overflow",
+            Error::Pipe => "Pipe error",
+            Error::Interrupted => "System call interrupted (perhaps due to signal)",
+            Error::NoMem => "Insufficient memory",
             Error::NotSupported => "Operation not supported or unimplemented on this platform",
-            Error::Other        => "Other error",
+            Error::Other => "Other error",
         }
     }
 }
@@ -89,24 +88,23 @@ impl StdError for Error {
     }
 }
 
-
 #[doc(hidden)]
 pub fn from_libusb(err: c_int) -> Error {
     match err {
-        LIBUSB_SUCCESS             => Error::Success,
-        LIBUSB_ERROR_IO            => Error::Io,
+        LIBUSB_SUCCESS => Error::Success,
+        LIBUSB_ERROR_IO => Error::Io,
         LIBUSB_ERROR_INVALID_PARAM => Error::InvalidParam,
-        LIBUSB_ERROR_ACCESS        => Error::Access,
-        LIBUSB_ERROR_NO_DEVICE     => Error::NoDevice,
-        LIBUSB_ERROR_NOT_FOUND     => Error::NotFound,
-        LIBUSB_ERROR_BUSY          => Error::Busy,
-        LIBUSB_ERROR_TIMEOUT       => Error::Timeout,
-        LIBUSB_ERROR_OVERFLOW      => Error::Overflow,
-        LIBUSB_ERROR_PIPE          => Error::Pipe,
-        LIBUSB_ERROR_INTERRUPTED   => Error::Interrupted,
-        LIBUSB_ERROR_NO_MEM        => Error::NoMem,
+        LIBUSB_ERROR_ACCESS => Error::Access,
+        LIBUSB_ERROR_NO_DEVICE => Error::NoDevice,
+        LIBUSB_ERROR_NOT_FOUND => Error::NotFound,
+        LIBUSB_ERROR_BUSY => Error::Busy,
+        LIBUSB_ERROR_TIMEOUT => Error::Timeout,
+        LIBUSB_ERROR_OVERFLOW => Error::Overflow,
+        LIBUSB_ERROR_PIPE => Error::Pipe,
+        LIBUSB_ERROR_INTERRUPTED => Error::Interrupted,
+        LIBUSB_ERROR_NO_MEM => Error::NoMem,
         LIBUSB_ERROR_NOT_SUPPORTED => Error::NotSupported,
-        LIBUSB_ERROR_OTHER | _     => Error::Other,
+        LIBUSB_ERROR_OTHER | _ => Error::Other,
     }
 }
 
@@ -117,5 +115,5 @@ macro_rules! try_unsafe {
             0 => (),
             err => return Err($crate::error::from_libusb(err)),
         }
-    }
+    };
 }

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -2,7 +2,7 @@ use libc::c_int;
 use libusb::*;
 
 /// Device speeds. Indicates the speed at which a device is operating.
-#[derive(Debug,PartialEq,Eq,Clone,Copy,Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum Speed {
     /// The operating system doesn't know the device speed.
     Unknown,
@@ -24,16 +24,16 @@ pub enum Speed {
 pub fn speed_from_libusb(n: c_int) -> Speed {
     match n {
         LIBUSB_SPEED_SUPER => Speed::Super,
-        LIBUSB_SPEED_HIGH  => Speed::High,
-        LIBUSB_SPEED_FULL  => Speed::Full,
-        LIBUSB_SPEED_LOW   => Speed::Low,
+        LIBUSB_SPEED_HIGH => Speed::High,
+        LIBUSB_SPEED_FULL => Speed::Full,
+        LIBUSB_SPEED_LOW => Speed::Low,
 
         LIBUSB_SPEED_UNKNOWN | _ => Speed::Unknown,
     }
 }
 
 /// Transfer and endpoint directions.
-#[derive(Debug,PartialEq,Eq,Clone,Copy,Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum Direction {
     /// Direction for read (device to host) transfers.
     In,
@@ -43,7 +43,7 @@ pub enum Direction {
 }
 
 /// An endpoint's transfer type.
-#[derive(Debug,PartialEq,Eq,Clone,Copy,Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum TransferType {
     /// Control endpoint.
     Control,
@@ -58,9 +58,8 @@ pub enum TransferType {
     Interrupt,
 }
 
-
 /// Isochronous synchronization mode.
-#[derive(Debug,PartialEq,Eq,Clone,Copy,Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum SyncType {
     /// No synchronisation.
     NoSync,
@@ -75,9 +74,8 @@ pub enum SyncType {
     Synchronous,
 }
 
-
 /// Isochronous usage type.
-#[derive(Debug,PartialEq,Eq,Clone,Copy,Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum UsageType {
     /// Data endpoint.
     Data,
@@ -92,9 +90,8 @@ pub enum UsageType {
     Reserved,
 }
 
-
 /// Types of control transfers.
-#[derive(Debug,PartialEq,Eq,Clone,Copy,Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum RequestType {
     /// Requests that are defined by the USB standard.
     Standard,
@@ -110,7 +107,7 @@ pub enum RequestType {
 }
 
 /// Recipients of control transfers.
-#[derive(Debug,PartialEq,Eq,Clone,Copy,Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum Recipient {
     /// The recipient is a device.
     Device,
@@ -139,7 +136,7 @@ pub enum Recipient {
 ///
 /// The intended use case of `Version` is to extract meaning from the version fields in USB
 /// descriptors, such as `bcdUSB` and `bcdDevice` in device descriptors.
-#[derive(Debug,PartialEq,Eq,Clone,Copy,Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Version(pub u8, pub u8, pub u8);
 
 impl Version {
@@ -199,26 +196,25 @@ impl Version {
 pub fn request_type(direction: Direction, request_type: RequestType, recipient: Recipient) -> u8 {
     let mut value: u8 = match direction {
         Direction::Out => LIBUSB_ENDPOINT_OUT,
-        Direction::In  => LIBUSB_ENDPOINT_IN,
+        Direction::In => LIBUSB_ENDPOINT_IN,
     };
 
     value |= match request_type {
         RequestType::Standard => LIBUSB_REQUEST_TYPE_STANDARD,
-        RequestType::Class    => LIBUSB_REQUEST_TYPE_CLASS,
-        RequestType::Vendor   => LIBUSB_REQUEST_TYPE_VENDOR,
+        RequestType::Class => LIBUSB_REQUEST_TYPE_CLASS,
+        RequestType::Vendor => LIBUSB_REQUEST_TYPE_VENDOR,
         RequestType::Reserved => LIBUSB_REQUEST_TYPE_RESERVED,
     };
 
     value |= match recipient {
-        Recipient::Device    => LIBUSB_RECIPIENT_DEVICE,
+        Recipient::Device => LIBUSB_RECIPIENT_DEVICE,
         Recipient::Interface => LIBUSB_RECIPIENT_INTERFACE,
-        Recipient::Endpoint  => LIBUSB_RECIPIENT_ENDPOINT,
-        Recipient::Other     => LIBUSB_RECIPIENT_OTHER,
+        Recipient::Endpoint => LIBUSB_RECIPIENT_ENDPOINT,
+        Recipient::Other => LIBUSB_RECIPIENT_OTHER,
     };
 
     value
 }
-
 
 #[cfg(test)]
 mod test {
@@ -275,55 +271,85 @@ mod test {
 
     #[test]
     fn request_type_builds_value_for_out_direction() {
-        assert_eq!(request_type(Direction::Out, RequestType::Standard, Recipient::Device) & 0x80, 0x00);
+        assert_eq!(
+            request_type(Direction::Out, RequestType::Standard, Recipient::Device) & 0x80,
+            0x00
+        );
     }
 
     #[test]
     fn request_type_builds_value_for_in_direction() {
-        assert_eq!(request_type(Direction::In, RequestType::Standard, Recipient::Device) & 0x80, 0x80);
+        assert_eq!(
+            request_type(Direction::In, RequestType::Standard, Recipient::Device) & 0x80,
+            0x80
+        );
     }
 
     // request_type for request type
 
     #[test]
     fn request_type_builds_value_for_standard_request() {
-        assert_eq!(request_type(Direction::Out, RequestType::Standard, Recipient::Device) & 0x60, 0x00);
+        assert_eq!(
+            request_type(Direction::Out, RequestType::Standard, Recipient::Device) & 0x60,
+            0x00
+        );
     }
 
     #[test]
     fn request_type_builds_value_for_class_request() {
-        assert_eq!(request_type(Direction::Out, RequestType::Class, Recipient::Device) & 0x60, 0x20);
+        assert_eq!(
+            request_type(Direction::Out, RequestType::Class, Recipient::Device) & 0x60,
+            0x20
+        );
     }
 
     #[test]
     fn request_type_builds_value_for_vendor_request() {
-        assert_eq!(request_type(Direction::Out, RequestType::Vendor, Recipient::Device) & 0x60, 0x40);
+        assert_eq!(
+            request_type(Direction::Out, RequestType::Vendor, Recipient::Device) & 0x60,
+            0x40
+        );
     }
 
     #[test]
     fn request_type_builds_value_for_reserved_request() {
-        assert_eq!(request_type(Direction::Out, RequestType::Reserved, Recipient::Device) & 0x60, 0x60);
+        assert_eq!(
+            request_type(Direction::Out, RequestType::Reserved, Recipient::Device) & 0x60,
+            0x60
+        );
     }
 
     // request_type for recipient
 
     #[test]
     fn request_type_builds_value_for_device_recipient() {
-        assert_eq!(request_type(Direction::Out, RequestType::Standard, Recipient::Device) & 0x0F, 0x00);
+        assert_eq!(
+            request_type(Direction::Out, RequestType::Standard, Recipient::Device) & 0x0F,
+            0x00
+        );
     }
 
     #[test]
     fn request_type_builds_value_for_interface_recipient() {
-        assert_eq!(request_type(Direction::Out, RequestType::Standard, Recipient::Interface) & 0x0F, 0x01);
+        assert_eq!(
+            request_type(Direction::Out, RequestType::Standard, Recipient::Interface) & 0x0F,
+            0x01
+        );
     }
 
     #[test]
     fn request_type_builds_value_for_endpoint_recipient() {
-        assert_eq!(request_type(Direction::Out, RequestType::Standard, Recipient::Endpoint) & 0x0F, 0x02);
+        assert_eq!(
+            request_type(Direction::Out, RequestType::Standard, Recipient::Endpoint) & 0x0F,
+            0x02
+        );
     }
 
     #[test]
     fn request_type_builds_value_for_other_recipient() {
-        assert_eq!(request_type(Direction::Out, RequestType::Standard, Recipient::Other) & 0x0F, 0x03);
+        assert_eq!(
+            request_type(Direction::Out, RequestType::Standard, Recipient::Other) & 0x0F,
+            0x03
+        );
     }
 }

--- a/src/interface_descriptor.rs
+++ b/src/interface_descriptor.rs
@@ -36,8 +36,8 @@ impl<'a> Iterator for InterfaceDescriptors<'a> {
     type Item = InterfaceDescriptor<'a>;
 
     fn next(&mut self) -> Option<InterfaceDescriptor<'a>> {
-        self.iter.next().map(|descriptor| {
-            InterfaceDescriptor { descriptor: descriptor }
+        self.iter.next().map(|descriptor| InterfaceDescriptor {
+            descriptor: descriptor,
         })
     }
 
@@ -45,7 +45,6 @@ impl<'a> Iterator for InterfaceDescriptors<'a> {
         self.iter.size_hint()
     }
 }
-
 
 /// Describes an alternate setting for an interface.
 pub struct InterfaceDescriptor<'a> {
@@ -96,11 +95,13 @@ impl<'a> InterfaceDescriptor<'a> {
         let endpoints = unsafe {
             slice::from_raw_parts(
                 self.descriptor.endpoint,
-                self.descriptor.bNumEndpoints as usize
+                self.descriptor.bNumEndpoints as usize,
             )
         };
 
-        EndpointDescriptors { iter: endpoints.iter() }
+        EndpointDescriptors {
+            iter: endpoints.iter(),
+        }
     }
 }
 
@@ -131,9 +132,9 @@ impl<'a> Iterator for EndpointDescriptors<'a> {
     type Item = EndpointDescriptor<'a>;
 
     fn next(&mut self) -> Option<EndpointDescriptor<'a>> {
-        self.iter.next().map(|endpoint| {
-            endpoint_descriptor::from_libusb(endpoint)
-        })
+        self.iter
+            .next()
+            .map(|endpoint| endpoint_descriptor::from_libusb(endpoint))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -141,56 +142,109 @@ impl<'a> Iterator for EndpointDescriptors<'a> {
     }
 }
 
-
 #[doc(hidden)]
 pub unsafe fn from_libusb(interface: &libusb_interface) -> Interface {
-    let descriptors = slice::from_raw_parts(interface.altsetting, interface.num_altsetting as usize);
+    let descriptors =
+        slice::from_raw_parts(interface.altsetting, interface.num_altsetting as usize);
     debug_assert!(descriptors.len() > 0);
 
-    Interface { descriptors: descriptors }
+    Interface {
+        descriptors: descriptors,
+    }
 }
-
 
 #[cfg(test)]
 mod test {
     #[test]
     fn it_has_interface_number() {
-        assert_eq!(42, unsafe { super::from_libusb(&interface!(interface_descriptor!(bInterfaceNumber: 42))) }.number());
+        assert_eq!(
+            42,
+            unsafe { super::from_libusb(&interface!(interface_descriptor!(bInterfaceNumber: 42))) }
+                .number()
+        );
     }
 
     #[test]
     fn it_has_interface_number_in_descriptor() {
-        assert_eq!(vec!(42), unsafe { super::from_libusb(&interface!(interface_descriptor!(bInterfaceNumber: 42))) }.descriptors().map(|setting| setting.interface_number()).collect::<Vec<_>>());
+        assert_eq!(
+            vec!(42),
+            unsafe { super::from_libusb(&interface!(interface_descriptor!(bInterfaceNumber: 42))) }
+                .descriptors()
+                .map(|setting| setting.interface_number())
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]
     fn it_has_alternate_setting_number() {
-        assert_eq!(vec!(42), unsafe { super::from_libusb(&interface!(interface_descriptor!(bAlternateSetting: 42))) }.descriptors().map(|setting| setting.setting_number()).collect::<Vec<_>>());
+        assert_eq!(
+            vec!(42),
+            unsafe {
+                super::from_libusb(&interface!(interface_descriptor!(bAlternateSetting: 42)))
+            }
+            .descriptors()
+            .map(|setting| setting.setting_number())
+            .collect::<Vec<_>>()
+        );
     }
 
     #[test]
     fn it_has_class_code() {
-        assert_eq!(vec!(42), unsafe { super::from_libusb(&interface!(interface_descriptor!(bInterfaceClass: 42))) }.descriptors().map(|setting| setting.class_code()).collect::<Vec<_>>());
+        assert_eq!(
+            vec!(42),
+            unsafe { super::from_libusb(&interface!(interface_descriptor!(bInterfaceClass: 42))) }
+                .descriptors()
+                .map(|setting| setting.class_code())
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]
     fn it_has_sub_class_code() {
-        assert_eq!(vec!(42), unsafe { super::from_libusb(&interface!(interface_descriptor!(bInterfaceSubClass: 42))) }.descriptors().map(|setting| setting.sub_class_code()).collect::<Vec<_>>());
+        assert_eq!(
+            vec!(42),
+            unsafe {
+                super::from_libusb(&interface!(interface_descriptor!(bInterfaceSubClass: 42)))
+            }
+            .descriptors()
+            .map(|setting| setting.sub_class_code())
+            .collect::<Vec<_>>()
+        );
     }
 
     #[test]
     fn it_has_protocol_code() {
-        assert_eq!(vec!(42), unsafe { super::from_libusb(&interface!(interface_descriptor!(bInterfaceProtocol: 42))) }.descriptors().map(|setting| setting.protocol_code()).collect::<Vec<_>>());
+        assert_eq!(
+            vec!(42),
+            unsafe {
+                super::from_libusb(&interface!(interface_descriptor!(bInterfaceProtocol: 42)))
+            }
+            .descriptors()
+            .map(|setting| setting.protocol_code())
+            .collect::<Vec<_>>()
+        );
     }
 
     #[test]
     fn it_has_description_string_index() {
-        assert_eq!(vec!(Some(42)), unsafe { super::from_libusb(&interface!(interface_descriptor!(iInterface: 42))) }.descriptors().map(|setting| setting.description_string_index()).collect::<Vec<_>>());
+        assert_eq!(
+            vec!(Some(42)),
+            unsafe { super::from_libusb(&interface!(interface_descriptor!(iInterface: 42))) }
+                .descriptors()
+                .map(|setting| setting.description_string_index())
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]
     fn it_handles_missing_description_string_index() {
-        assert_eq!(vec!(None), unsafe { super::from_libusb(&interface!(interface_descriptor!(iInterface: 0))) }.descriptors().map(|setting| setting.description_string_index()).collect::<Vec<_>>());
+        assert_eq!(
+            vec!(None),
+            unsafe { super::from_libusb(&interface!(interface_descriptor!(iInterface: 0))) }
+                .descriptors()
+                .map(|setting| setting.description_string_index())
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]
@@ -198,17 +252,29 @@ mod test {
         let endpoint1 = endpoint_descriptor!(bEndpointAddress: 0x81);
         let endpoint2 = endpoint_descriptor!(bEndpointAddress: 0x01);
 
-        assert_eq!(vec!(2), unsafe { super::from_libusb(&interface!(interface_descriptor!(endpoint1, endpoint2))) }.descriptors().map(|setting| setting.num_endpoints()).collect::<Vec<_>>());
+        assert_eq!(
+            vec!(2),
+            unsafe { super::from_libusb(&interface!(interface_descriptor!(endpoint1, endpoint2))) }
+                .descriptors()
+                .map(|setting| setting.num_endpoints())
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]
     fn it_has_endpoints() {
-        let libusb_interface = interface!(interface_descriptor!(endpoint_descriptor!(bEndpointAddress: 0x87)));
+        let libusb_interface = interface!(interface_descriptor!(
+            endpoint_descriptor!(bEndpointAddress: 0x87)
+        ));
         let interface = unsafe { super::from_libusb(&libusb_interface) };
 
-        let endpoint_addresses = interface.descriptors().next().unwrap().endpoint_descriptors().map(|endpoint| {
-            endpoint.address()
-        }).collect::<Vec<_>>();
+        let endpoint_addresses = interface
+            .descriptors()
+            .next()
+            .unwrap()
+            .endpoint_descriptors()
+            .map(|endpoint| endpoint.address())
+            .collect::<Vec<_>>();
 
         assert_eq!(vec![0x87], endpoint_addresses);
     }

--- a/src/interface_descriptor.rs
+++ b/src/interface_descriptor.rs
@@ -3,7 +3,7 @@ use std::slice;
 
 use libusb::*;
 
-use endpoint_descriptor::{self, EndpointDescriptor};
+use crate::endpoint_descriptor::{self, EndpointDescriptor};
 
 /// A device interface.
 ///

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,6 +1,5 @@
 const PRIMARY_LANGUAGE_MASK: u16 = 0x03FF;
-const SUB_LANGUAGE_MASK:     u16 = 0xFC00;
-
+const SUB_LANGUAGE_MASK: u16 = 0xFC00;
 
 /// A language used to read string descriptors from USB devices.
 ///
@@ -9,7 +8,7 @@ const SUB_LANGUAGE_MASK:     u16 = 0xFC00;
 /// The dialect may be based on regional differences (United States English compared to United
 /// Kindgdom English), writing systems (Cyrillic compared to Latin), or age (Modern compared to
 /// Traditional). Each primary language has its own set of sub languages.
-#[derive(Debug,Copy,Clone,PartialEq,Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Language {
     raw: u16,
 }
@@ -39,9 +38,8 @@ pub fn from_lang_id(raw: u16) -> Language {
     Language { raw: raw }
 }
 
-
 /// Primary language families.
-#[derive(Debug,Copy,Clone,PartialEq,Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PrimaryLanguage {
     Afrikaans,
     Albanian,
@@ -136,11 +134,9 @@ impl PrimaryLanguage {
             0x0055 => PrimaryLanguage::Burmese,
             0x0003 => PrimaryLanguage::Catalan,
             0x0004 => PrimaryLanguage::Chinese,
-            0x001A => {
-                match raw & SUB_LANGUAGE_MASK {
-                    0x0400 => PrimaryLanguage::Croatian,
-                    _      => PrimaryLanguage::Serbian,
-                }
+            0x001A => match raw & SUB_LANGUAGE_MASK {
+                0x0400 => PrimaryLanguage::Croatian,
+                _ => PrimaryLanguage::Serbian,
             },
             0x0005 => PrimaryLanguage::Czech,
             0x0006 => PrimaryLanguage::Danish,
@@ -200,96 +196,95 @@ impl PrimaryLanguage {
             0x0043 => PrimaryLanguage::Uzbek,
             0x002A => PrimaryLanguage::Vietnamese,
             0x00FF => PrimaryLanguage::HID,
-            n      => PrimaryLanguage::Other(n),
+            n => PrimaryLanguage::Other(n),
         }
     }
 }
 
-
 /// Language dialects and writing systems.
-#[derive(Debug,Copy,Clone,PartialEq,Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SubLanguage {
     Standard,
     Classic,
     Traditional,
     Modern,
 
-    Algeria, // arabic
-    Argentina, // spanish
-    Australia, // english
-    Austria, // german
-    Bahrain, // arabic
-    Belgium, // dutch, french
-    Belize, // english
-    Bokmal, // norwegian
-    Bolivia, // spanish
-    Brazil, // portuguese
-    BruneiDarussalam, // malay
-    Canada, // english, french
-    Caribbean, // english
-    Chile, // spanish
-    China, // chinese
-    Colombia, // spanish
-    CostaRica, // spanish
-    Cyrillic, // azeri, serbian, uzbek
-    DominicanRepublic, // spanish
-    Ecuador, // spanish
-    Egypt, // arabic
-    ElSalvador, // spanish
-    Finland, // swedish
-    Guatemala, // spanish
-    Honduras, // spanish
-    HongKong, // chinese
-    India, // kashmiri, nepali, urdu
-    Iraq, // arabic
-    Ireland, // english
-    Jamaica, // english
-    Johab, // korean
-    Jordan, // arabic
-    Kuwait, // arabic
-    Latin, // azeri, serbian, uzbek
-    Lebanon, // arabic
-    Libya, // arabic
-    Liechtenstein, // german
-    Luxembourg, // french, german
-    Macau, // chinese
-    Malaysia, // malay
-    Mexico, // spanish
-    Monaco, // french
-    Morocco, // arabic
-    Netherlands, // dutch
-    NewZealand, // english
-    Nicaragua, // spanish
-    Nynorsk, // norwegian
-    Oman, // arabic
-    Pakistan, // urdu
-    Panama, // spanish
-    Paraguay, // spanish
-    Peru, // spanish
-    Philippines, // english
-    PuertoRico, // spanish
-    Qatar, // arabic
-    SaudiArabia, // arabic
-    Singapore, // chinese
-    SouthAfrica, // english
-    Switzerland, // french, german, italian
-    Syria, // arabic
-    Taiwan, // chinese
-    Trinidad, // english
-    Tunisia, // arabic
+    Algeria,            // arabic
+    Argentina,          // spanish
+    Australia,          // english
+    Austria,            // german
+    Bahrain,            // arabic
+    Belgium,            // dutch, french
+    Belize,             // english
+    Bokmal,             // norwegian
+    Bolivia,            // spanish
+    Brazil,             // portuguese
+    BruneiDarussalam,   // malay
+    Canada,             // english, french
+    Caribbean,          // english
+    Chile,              // spanish
+    China,              // chinese
+    Colombia,           // spanish
+    CostaRica,          // spanish
+    Cyrillic,           // azeri, serbian, uzbek
+    DominicanRepublic,  // spanish
+    Ecuador,            // spanish
+    Egypt,              // arabic
+    ElSalvador,         // spanish
+    Finland,            // swedish
+    Guatemala,          // spanish
+    Honduras,           // spanish
+    HongKong,           // chinese
+    India,              // kashmiri, nepali, urdu
+    Iraq,               // arabic
+    Ireland,            // english
+    Jamaica,            // english
+    Johab,              // korean
+    Jordan,             // arabic
+    Kuwait,             // arabic
+    Latin,              // azeri, serbian, uzbek
+    Lebanon,            // arabic
+    Libya,              // arabic
+    Liechtenstein,      // german
+    Luxembourg,         // french, german
+    Macau,              // chinese
+    Malaysia,           // malay
+    Mexico,             // spanish
+    Monaco,             // french
+    Morocco,            // arabic
+    Netherlands,        // dutch
+    NewZealand,         // english
+    Nicaragua,          // spanish
+    Nynorsk,            // norwegian
+    Oman,               // arabic
+    Pakistan,           // urdu
+    Panama,             // spanish
+    Paraguay,           // spanish
+    Peru,               // spanish
+    Philippines,        // english
+    PuertoRico,         // spanish
+    Qatar,              // arabic
+    SaudiArabia,        // arabic
+    Singapore,          // chinese
+    SouthAfrica,        // english
+    Switzerland,        // french, german, italian
+    Syria,              // arabic
+    Taiwan,             // chinese
+    Trinidad,           // english
+    Tunisia,            // arabic
     UnitedArabEmirates, // arabic
-    UnitedKingdom, // english
-    UnitedStates, // english
-    Uruguay, // spanish
-    Venezuela, // spanish
-    Yemen, // arabic
-    Zimbabwe, // english
+    UnitedKingdom,      // english
+    UnitedStates,       // english
+    Uruguay,            // spanish
+    Venezuela,          // spanish
+    Yemen,              // arabic
+    Zimbabwe,           // english
 
     UsageDataDescriptor, // HID
-    VendorDefined1, // HID
-    VendorDefined2, // HID
-    VendorDefined3, // HID
-    VendorDefined4, // HID
+    VendorDefined1,      // HID
+    VendorDefined2,      // HID
+    VendorDefined3,      // HID
+    VendorDefined4,      // HID
 
     Other(u16),
 }
@@ -314,12 +309,12 @@ impl SubLanguage {
                 0x3800 => SubLanguage::UnitedArabEmirates,
                 0x3C00 => SubLanguage::Bahrain,
                 0x4000 => SubLanguage::Qatar,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Azeri => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Latin,
                 0x0800 => SubLanguage::Cyrillic,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Chinese => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Taiwan,
@@ -327,12 +322,12 @@ impl SubLanguage {
                 0x0C00 => SubLanguage::HongKong,
                 0x1000 => SubLanguage::Singapore,
                 0x1400 => SubLanguage::Macau,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Dutch => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Netherlands,
                 0x0800 => SubLanguage::Belgium,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::English => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::UnitedStates,
@@ -348,7 +343,7 @@ impl SubLanguage {
                 0x2C00 => SubLanguage::Trinidad,
                 0x3000 => SubLanguage::Zimbabwe,
                 0x3400 => SubLanguage::Philippines,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::French => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Standard,
@@ -357,7 +352,7 @@ impl SubLanguage {
                 0x1000 => SubLanguage::Switzerland,
                 0x1400 => SubLanguage::Luxembourg,
                 0x1800 => SubLanguage::Monaco,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::German => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Standard,
@@ -365,42 +360,42 @@ impl SubLanguage {
                 0x0C00 => SubLanguage::Austria,
                 0x1000 => SubLanguage::Luxembourg,
                 0x1400 => SubLanguage::Liechtenstein,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Italian => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Standard,
                 0x0800 => SubLanguage::Switzerland,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Korean => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Standard,
                 0x0800 => SubLanguage::Johab,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Lithuanian => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Standard,
                 0x0800 => SubLanguage::Classic,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Malay => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Malaysia,
                 0x0800 => SubLanguage::BruneiDarussalam,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Norwegian => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Bokmal,
                 0x0800 => SubLanguage::Nynorsk,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Portuguese => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Brazil,
                 0x0800 => SubLanguage::Standard,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Serbian => match raw & SUB_LANGUAGE_MASK {
                 0x0C00 => SubLanguage::Cyrillic,
                 0x0800 => SubLanguage::Latin,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Spanish => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Traditional,
@@ -423,22 +418,22 @@ impl SubLanguage {
                 0x4800 => SubLanguage::Honduras,
                 0x4C00 => SubLanguage::Nicaragua,
                 0x5000 => SubLanguage::PuertoRico,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Swedish => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Standard,
                 0x0800 => SubLanguage::Finland,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Urdu => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Pakistan,
                 0x0800 => SubLanguage::India,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Uzbek => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::Latin,
                 0x0800 => SubLanguage::Cyrillic,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::HID => match raw & SUB_LANGUAGE_MASK {
                 0x0400 => SubLanguage::UsageDataDescriptor,
@@ -446,7 +441,7 @@ impl SubLanguage {
                 0xF400 => SubLanguage::VendorDefined2,
                 0xF800 => SubLanguage::VendorDefined3,
                 0xFC00 => SubLanguage::VendorDefined4,
-                n      => SubLanguage::Other(n),
+                n => SubLanguage::Other(n),
             },
             PrimaryLanguage::Other(_) => SubLanguage::Other(raw & SUB_LANGUAGE_MASK),
             _ => SubLanguage::Standard,
@@ -454,1380 +449,2110 @@ impl SubLanguage {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::{PrimaryLanguage, SubLanguage};
     use super::{PRIMARY_LANGUAGE_MASK, SUB_LANGUAGE_MASK};
 
     // language ids defined in http://www.usb.org/developers/docs/USB_LANGIDs.pdf
-    const AFRIKAANS:                  u16 = 0x0436;
-    const ALBANIAN:                   u16 = 0x041C;
-    const ARABIC_SAUDI_ARABIA:        u16 = 0x0401;
-    const ARABIC_IRAQ:                u16 = 0x0801;
-    const ARABIC_EGYPT:               u16 = 0x0C01;
-    const ARABIC_LIBYA:               u16 = 0x1001;
-    const ARABIC_ALGERIA:             u16 = 0x1401;
-    const ARABIC_MOROCCO:             u16 = 0x1801;
-    const ARABIC_TUNISIA:             u16 = 0x1C01;
-    const ARABIC_OMAN:                u16 = 0x2001;
-    const ARABIC_YEMEN:               u16 = 0x2401;
-    const ARABIC_SYRIA:               u16 = 0x2801;
-    const ARABIC_JORDAN:              u16 = 0x2C01;
-    const ARABIC_LEBANON:             u16 = 0x3001;
-    const ARABIC_KUWAIT:              u16 = 0x3401;
-    const ARABIC_UAE:                 u16 = 0x3801;
-    const ARABIC_BAHRAIN:             u16 = 0x3C01;
-    const ARABIC_QATAR:               u16 = 0x4001;
-    const ARMENIAN:                   u16 = 0x042B;
-    const ASSAMESE:                   u16 = 0x044D;
-    const AZERI_LATIN:                u16 = 0x042C;
-    const AZERI_CYRILLIC:             u16 = 0x082C;
-    const BASQUE:                     u16 = 0x042D;
-    const BELARUSSIAN:                u16 = 0x0423;
-    const BENGALI:                    u16 = 0x0445;
-    const BULGARIAN:                  u16 = 0x0402;
-    const BURMESE:                    u16 = 0x0455;
-    const CATALAN:                    u16 = 0x0403;
-    const CHINESE_TAIWAN:             u16 = 0x0404;
-    const CHINESE_CHINA:              u16 = 0x0804;
-    const CHINESE_HONG_KONG:          u16 = 0x0C04;
-    const CHINESE_SINGAPORE:          u16 = 0x1004;
-    const CHINESE_MACAU:              u16 = 0x1404;
-    const CROATIAN:                   u16 = 0x041A;
-    const CZECH:                      u16 = 0x0405;
-    const DANISH:                     u16 = 0x0406;
-    const DUTCH_NETHERLANDS:          u16 = 0x0413;
-    const DUTCH_BELGIUM:              u16 = 0x0813;
-    const ENGLISH_UNITED_STATES:      u16 = 0x0409;
-    const ENGLISH_UNITED_KINGDOM:     u16 = 0x0809;
-    const ENGLISH_AUSTRALIAN:         u16 = 0x0C09;
-    const ENGLISH_CANADIAN:           u16 = 0x1009;
-    const ENGLISH_NEW_ZEALAND:        u16 = 0x1409;
-    const ENGLISH_IRELAND:            u16 = 0x1809;
-    const ENGLISH_SOUTH_AFRICA:       u16 = 0x1C09;
-    const ENGLISH_JAMAICA:            u16 = 0x2009;
-    const ENGLISH_CARIBBEAN:          u16 = 0x2409;
-    const ENGLISH_BELIZE:             u16 = 0x2809;
-    const ENGLISH_TRINIDAD:           u16 = 0x2C09;
-    const ENGLISH_ZIMBABWE:           u16 = 0x3009;
-    const ENGLISH_PHILIPPINES:        u16 = 0x3409;
-    const ESTONIAN:                   u16 = 0x0425;
-    const FAEROESE:                   u16 = 0x0438;
-    const FARSI:                      u16 = 0x0429;
-    const FINNISH:                    u16 = 0x040B;
-    const FRENCH_STANDARD:            u16 = 0x040C;
-    const FRENCH_BELGIAN:             u16 = 0x080C;
-    const FRENCH_CANADIAN:            u16 = 0x0C0C;
-    const FRENCH_SWITZERLAND:         u16 = 0x100C;
-    const FRENCH_LUXEMBOURG:          u16 = 0x140C;
-    const FRENCH_MONACO:              u16 = 0x180C;
-    const GEORGIAN:                   u16 = 0x0437;
-    const GERMAN_STANDARD:            u16 = 0x0407;
-    const GERMAN_SWITZERLAND:         u16 = 0x0807;
-    const GERMAN_AUSTRIA:             u16 = 0x0C07;
-    const GERMAN_LUXEMBOURG:          u16 = 0x1007;
-    const GERMAN_LIECHTENSTEIN:       u16 = 0x1407;
-    const GREEK:                      u16 = 0x0408;
-    const GUJARATI:                   u16 = 0x0447;
-    const HEBREW:                     u16 = 0x040D;
-    const HINDI:                      u16 = 0x0439;
-    const HUNGARIAN:                  u16 = 0x040E;
-    const ICELANDIC:                  u16 = 0x040F;
-    const INDONESIAN:                 u16 = 0x0421;
-    const ITALIAN_STANDARD:           u16 = 0x0410;
-    const ITALIAN_SWITZERLAND:        u16 = 0x0810;
-    const JAPANESE:                   u16 = 0x0411;
-    const KANNADA:                    u16 = 0x044B;
-    const KASHMIRI_INDIA:             u16 = 0x0860;
-    const KAZAKH:                     u16 = 0x043F;
-    const KONKANI:                    u16 = 0x0457;
-    const KOREAN:                     u16 = 0x0412;
-    const KOREAN_JOHAB:               u16 = 0x0812;
-    const LATVIAN:                    u16 = 0x0426;
-    const LITHUANIAN:                 u16 = 0x0427;
-    const LITHUANIAN_CLASSIC:         u16 = 0x0827;
-    const MACEDONIAN:                 u16 = 0x042F;
-    const MALAY_MALAYSIAN:            u16 = 0x043E;
-    const MALAY_BRUNEI_DARUSSALAM:    u16 = 0x083E;
-    const MALAYALAM:                  u16 = 0x044C;
-    const MANIPURI:                   u16 = 0x0458;
-    const MARATHI:                    u16 = 0x044E;
-    const NEPALI_INDIA:               u16 = 0x0861;
-    const NORWEGIAN_BOKMAL:           u16 = 0x0414;
-    const NORWEGIAN_NYNORSK:          u16 = 0x0814;
-    const ORIYA:                      u16 = 0x0448;
-    const POLISH:                     u16 = 0x0415;
-    const PORTUGUESE_BRAZIL:          u16 = 0x0416;
-    const PORTUGUESE_STANDARD:        u16 = 0x0816;
-    const PUNJABI:                    u16 = 0x0446;
-    const ROMANIAN:                   u16 = 0x0418;
-    const RUSSIAN:                    u16 = 0x0419;
-    const SANSKRIT:                   u16 = 0x044F;
-    const SERBIAN_CYRILLIC:           u16 = 0x0C1A;
-    const SERBIAN_LATIN:              u16 = 0x081A;
-    const SINDHI:                     u16 = 0x0459;
-    const SLOVAK:                     u16 = 0x041B;
-    const SLOVENIAN:                  u16 = 0x0424;
-    const SPANISH_TRADITIONAL_SORT:   u16 = 0x040A;
-    const SPANISH_MEXICAN:            u16 = 0x080A;
-    const SPANISH_MODERN_SORT:        u16 = 0x0C0A;
-    const SPANISH_GUATEMALA:          u16 = 0x100A;
-    const SPANISH_COSTA_RICA:         u16 = 0x140A;
-    const SPANISH_PANAMA:             u16 = 0x180A;
+    const AFRIKAANS: u16 = 0x0436;
+    const ALBANIAN: u16 = 0x041C;
+    const ARABIC_SAUDI_ARABIA: u16 = 0x0401;
+    const ARABIC_IRAQ: u16 = 0x0801;
+    const ARABIC_EGYPT: u16 = 0x0C01;
+    const ARABIC_LIBYA: u16 = 0x1001;
+    const ARABIC_ALGERIA: u16 = 0x1401;
+    const ARABIC_MOROCCO: u16 = 0x1801;
+    const ARABIC_TUNISIA: u16 = 0x1C01;
+    const ARABIC_OMAN: u16 = 0x2001;
+    const ARABIC_YEMEN: u16 = 0x2401;
+    const ARABIC_SYRIA: u16 = 0x2801;
+    const ARABIC_JORDAN: u16 = 0x2C01;
+    const ARABIC_LEBANON: u16 = 0x3001;
+    const ARABIC_KUWAIT: u16 = 0x3401;
+    const ARABIC_UAE: u16 = 0x3801;
+    const ARABIC_BAHRAIN: u16 = 0x3C01;
+    const ARABIC_QATAR: u16 = 0x4001;
+    const ARMENIAN: u16 = 0x042B;
+    const ASSAMESE: u16 = 0x044D;
+    const AZERI_LATIN: u16 = 0x042C;
+    const AZERI_CYRILLIC: u16 = 0x082C;
+    const BASQUE: u16 = 0x042D;
+    const BELARUSSIAN: u16 = 0x0423;
+    const BENGALI: u16 = 0x0445;
+    const BULGARIAN: u16 = 0x0402;
+    const BURMESE: u16 = 0x0455;
+    const CATALAN: u16 = 0x0403;
+    const CHINESE_TAIWAN: u16 = 0x0404;
+    const CHINESE_CHINA: u16 = 0x0804;
+    const CHINESE_HONG_KONG: u16 = 0x0C04;
+    const CHINESE_SINGAPORE: u16 = 0x1004;
+    const CHINESE_MACAU: u16 = 0x1404;
+    const CROATIAN: u16 = 0x041A;
+    const CZECH: u16 = 0x0405;
+    const DANISH: u16 = 0x0406;
+    const DUTCH_NETHERLANDS: u16 = 0x0413;
+    const DUTCH_BELGIUM: u16 = 0x0813;
+    const ENGLISH_UNITED_STATES: u16 = 0x0409;
+    const ENGLISH_UNITED_KINGDOM: u16 = 0x0809;
+    const ENGLISH_AUSTRALIAN: u16 = 0x0C09;
+    const ENGLISH_CANADIAN: u16 = 0x1009;
+    const ENGLISH_NEW_ZEALAND: u16 = 0x1409;
+    const ENGLISH_IRELAND: u16 = 0x1809;
+    const ENGLISH_SOUTH_AFRICA: u16 = 0x1C09;
+    const ENGLISH_JAMAICA: u16 = 0x2009;
+    const ENGLISH_CARIBBEAN: u16 = 0x2409;
+    const ENGLISH_BELIZE: u16 = 0x2809;
+    const ENGLISH_TRINIDAD: u16 = 0x2C09;
+    const ENGLISH_ZIMBABWE: u16 = 0x3009;
+    const ENGLISH_PHILIPPINES: u16 = 0x3409;
+    const ESTONIAN: u16 = 0x0425;
+    const FAEROESE: u16 = 0x0438;
+    const FARSI: u16 = 0x0429;
+    const FINNISH: u16 = 0x040B;
+    const FRENCH_STANDARD: u16 = 0x040C;
+    const FRENCH_BELGIAN: u16 = 0x080C;
+    const FRENCH_CANADIAN: u16 = 0x0C0C;
+    const FRENCH_SWITZERLAND: u16 = 0x100C;
+    const FRENCH_LUXEMBOURG: u16 = 0x140C;
+    const FRENCH_MONACO: u16 = 0x180C;
+    const GEORGIAN: u16 = 0x0437;
+    const GERMAN_STANDARD: u16 = 0x0407;
+    const GERMAN_SWITZERLAND: u16 = 0x0807;
+    const GERMAN_AUSTRIA: u16 = 0x0C07;
+    const GERMAN_LUXEMBOURG: u16 = 0x1007;
+    const GERMAN_LIECHTENSTEIN: u16 = 0x1407;
+    const GREEK: u16 = 0x0408;
+    const GUJARATI: u16 = 0x0447;
+    const HEBREW: u16 = 0x040D;
+    const HINDI: u16 = 0x0439;
+    const HUNGARIAN: u16 = 0x040E;
+    const ICELANDIC: u16 = 0x040F;
+    const INDONESIAN: u16 = 0x0421;
+    const ITALIAN_STANDARD: u16 = 0x0410;
+    const ITALIAN_SWITZERLAND: u16 = 0x0810;
+    const JAPANESE: u16 = 0x0411;
+    const KANNADA: u16 = 0x044B;
+    const KASHMIRI_INDIA: u16 = 0x0860;
+    const KAZAKH: u16 = 0x043F;
+    const KONKANI: u16 = 0x0457;
+    const KOREAN: u16 = 0x0412;
+    const KOREAN_JOHAB: u16 = 0x0812;
+    const LATVIAN: u16 = 0x0426;
+    const LITHUANIAN: u16 = 0x0427;
+    const LITHUANIAN_CLASSIC: u16 = 0x0827;
+    const MACEDONIAN: u16 = 0x042F;
+    const MALAY_MALAYSIAN: u16 = 0x043E;
+    const MALAY_BRUNEI_DARUSSALAM: u16 = 0x083E;
+    const MALAYALAM: u16 = 0x044C;
+    const MANIPURI: u16 = 0x0458;
+    const MARATHI: u16 = 0x044E;
+    const NEPALI_INDIA: u16 = 0x0861;
+    const NORWEGIAN_BOKMAL: u16 = 0x0414;
+    const NORWEGIAN_NYNORSK: u16 = 0x0814;
+    const ORIYA: u16 = 0x0448;
+    const POLISH: u16 = 0x0415;
+    const PORTUGUESE_BRAZIL: u16 = 0x0416;
+    const PORTUGUESE_STANDARD: u16 = 0x0816;
+    const PUNJABI: u16 = 0x0446;
+    const ROMANIAN: u16 = 0x0418;
+    const RUSSIAN: u16 = 0x0419;
+    const SANSKRIT: u16 = 0x044F;
+    const SERBIAN_CYRILLIC: u16 = 0x0C1A;
+    const SERBIAN_LATIN: u16 = 0x081A;
+    const SINDHI: u16 = 0x0459;
+    const SLOVAK: u16 = 0x041B;
+    const SLOVENIAN: u16 = 0x0424;
+    const SPANISH_TRADITIONAL_SORT: u16 = 0x040A;
+    const SPANISH_MEXICAN: u16 = 0x080A;
+    const SPANISH_MODERN_SORT: u16 = 0x0C0A;
+    const SPANISH_GUATEMALA: u16 = 0x100A;
+    const SPANISH_COSTA_RICA: u16 = 0x140A;
+    const SPANISH_PANAMA: u16 = 0x180A;
     const SPANISH_DOMINICAN_REPUBLIC: u16 = 0x1C0A;
-    const SPANISH_VENEZUELA:          u16 = 0x200A;
-    const SPANISH_COLOMBIA:           u16 = 0x240A;
-    const SPANISH_PERU:               u16 = 0x280A;
-    const SPANISH_ARGENTINA:          u16 = 0x2C0A;
-    const SPANISH_ECUADOR:            u16 = 0x300A;
-    const SPANISH_CHILE:              u16 = 0x340A;
-    const SPANISH_URUGUAY:            u16 = 0x380A;
-    const SPANISH_PARAGUAY:           u16 = 0x3C0A;
-    const SPANISH_BOLIVIA:            u16 = 0x400A;
-    const SPANISH_EL_SALVADOR:        u16 = 0x440A;
-    const SPANISH_HONDURAS:           u16 = 0x480A;
-    const SPANISH_NICARAGUA:          u16 = 0x4C0A;
-    const SPANISH_PUERTO_RICO:        u16 = 0x500A;
-    const SUTU:                       u16 = 0x0430;
-    const SWAHILI_KENYA:              u16 = 0x0441;
-    const SWEDISH:                    u16 = 0x041D;
-    const SWEDISH_FINLAND:            u16 = 0x081D;
-    const TAMIL:                      u16 = 0x0449;
-    const TATAR_TATARSTAN:            u16 = 0x0444;
-    const TELUGU:                     u16 = 0x044A;
-    const THAI:                       u16 = 0x041E;
-    const TURKISH:                    u16 = 0x041F;
-    const UKRAINIAN:                  u16 = 0x0422;
-    const URDU_PAKISTAN:              u16 = 0x0420;
-    const URDU_INDIA:                 u16 = 0x0820;
-    const UZBEK_LATIN:                u16 = 0x0443;
-    const UZBEK_CYRILLIC:             u16 = 0x0843;
-    const VIETNAMESE:                 u16 = 0x042A;
-    const HID_USAGE_DATA_DESCRIPTOR:  u16 = 0x04FF;
-    const HID_VENDOR_DEFINED_1:       u16 = 0xF0FF;
-    const HID_VENDOR_DEFINED_2:       u16 = 0xF4FF;
-    const HID_VENDOR_DEFINED_3:       u16 = 0xF8FF;
-    const HID_VENDOR_DEFINED_4:       u16 = 0xFCFF;
-
+    const SPANISH_VENEZUELA: u16 = 0x200A;
+    const SPANISH_COLOMBIA: u16 = 0x240A;
+    const SPANISH_PERU: u16 = 0x280A;
+    const SPANISH_ARGENTINA: u16 = 0x2C0A;
+    const SPANISH_ECUADOR: u16 = 0x300A;
+    const SPANISH_CHILE: u16 = 0x340A;
+    const SPANISH_URUGUAY: u16 = 0x380A;
+    const SPANISH_PARAGUAY: u16 = 0x3C0A;
+    const SPANISH_BOLIVIA: u16 = 0x400A;
+    const SPANISH_EL_SALVADOR: u16 = 0x440A;
+    const SPANISH_HONDURAS: u16 = 0x480A;
+    const SPANISH_NICARAGUA: u16 = 0x4C0A;
+    const SPANISH_PUERTO_RICO: u16 = 0x500A;
+    const SUTU: u16 = 0x0430;
+    const SWAHILI_KENYA: u16 = 0x0441;
+    const SWEDISH: u16 = 0x041D;
+    const SWEDISH_FINLAND: u16 = 0x081D;
+    const TAMIL: u16 = 0x0449;
+    const TATAR_TATARSTAN: u16 = 0x0444;
+    const TELUGU: u16 = 0x044A;
+    const THAI: u16 = 0x041E;
+    const TURKISH: u16 = 0x041F;
+    const UKRAINIAN: u16 = 0x0422;
+    const URDU_PAKISTAN: u16 = 0x0420;
+    const URDU_INDIA: u16 = 0x0820;
+    const UZBEK_LATIN: u16 = 0x0443;
+    const UZBEK_CYRILLIC: u16 = 0x0843;
+    const VIETNAMESE: u16 = 0x042A;
+    const HID_USAGE_DATA_DESCRIPTOR: u16 = 0x04FF;
+    const HID_VENDOR_DEFINED_1: u16 = 0xF0FF;
+    const HID_VENDOR_DEFINED_2: u16 = 0xF4FF;
+    const HID_VENDOR_DEFINED_3: u16 = 0xF8FF;
+    const HID_VENDOR_DEFINED_4: u16 = 0xFCFF;
 
     #[test]
     fn it_recognizes_afrikaans_as_afrikaans_language() {
-        assert_eq!(super::from_lang_id(AFRIKAANS).primary_language(), PrimaryLanguage::Afrikaans);
+        assert_eq!(
+            super::from_lang_id(AFRIKAANS).primary_language(),
+            PrimaryLanguage::Afrikaans
+        );
     }
 
     #[test]
     fn it_recognizes_albanian_as_albanian_language() {
-        assert_eq!(super::from_lang_id(ALBANIAN).primary_language(), PrimaryLanguage::Albanian);
+        assert_eq!(
+            super::from_lang_id(ALBANIAN).primary_language(),
+            PrimaryLanguage::Albanian
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_saudi_arabia_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_SAUDI_ARABIA).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_SAUDI_ARABIA).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_saudi_arabia_as_saudi_arabia_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_SAUDI_ARABIA).sub_language(), SubLanguage::SaudiArabia);
+        assert_eq!(
+            super::from_lang_id(ARABIC_SAUDI_ARABIA).sub_language(),
+            SubLanguage::SaudiArabia
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_iraq_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_IRAQ).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_IRAQ).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_iraq_as_iraq_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_IRAQ).sub_language(), SubLanguage::Iraq);
+        assert_eq!(
+            super::from_lang_id(ARABIC_IRAQ).sub_language(),
+            SubLanguage::Iraq
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_egypt_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_EGYPT).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_EGYPT).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_egypt_as_egypt_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_EGYPT).sub_language(), SubLanguage::Egypt);
+        assert_eq!(
+            super::from_lang_id(ARABIC_EGYPT).sub_language(),
+            SubLanguage::Egypt
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_libya_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_LIBYA).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_LIBYA).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_libya_as_libya_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_LIBYA).sub_language(), SubLanguage::Libya);
+        assert_eq!(
+            super::from_lang_id(ARABIC_LIBYA).sub_language(),
+            SubLanguage::Libya
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_algeria_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_ALGERIA).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_ALGERIA).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_algeria_as_algeria_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_ALGERIA).sub_language(), SubLanguage::Algeria);
+        assert_eq!(
+            super::from_lang_id(ARABIC_ALGERIA).sub_language(),
+            SubLanguage::Algeria
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_morocco_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_MOROCCO).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_MOROCCO).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_morocco_as_morocco_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_MOROCCO).sub_language(), SubLanguage::Morocco);
+        assert_eq!(
+            super::from_lang_id(ARABIC_MOROCCO).sub_language(),
+            SubLanguage::Morocco
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_tunisia_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_TUNISIA).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_TUNISIA).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_tunisia_as_tunisia_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_TUNISIA).sub_language(), SubLanguage::Tunisia);
+        assert_eq!(
+            super::from_lang_id(ARABIC_TUNISIA).sub_language(),
+            SubLanguage::Tunisia
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_oman_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_OMAN).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_OMAN).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_oman_as_oman_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_OMAN).sub_language(), SubLanguage::Oman);
+        assert_eq!(
+            super::from_lang_id(ARABIC_OMAN).sub_language(),
+            SubLanguage::Oman
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_yemen_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_YEMEN).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_YEMEN).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_yemen_as_yemen_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_YEMEN).sub_language(), SubLanguage::Yemen);
+        assert_eq!(
+            super::from_lang_id(ARABIC_YEMEN).sub_language(),
+            SubLanguage::Yemen
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_syria_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_SYRIA).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_SYRIA).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_syria_as_syria_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_SYRIA).sub_language(), SubLanguage::Syria);
+        assert_eq!(
+            super::from_lang_id(ARABIC_SYRIA).sub_language(),
+            SubLanguage::Syria
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_jordan_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_JORDAN).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_JORDAN).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_jordan_as_jordan_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_JORDAN).sub_language(), SubLanguage::Jordan);
+        assert_eq!(
+            super::from_lang_id(ARABIC_JORDAN).sub_language(),
+            SubLanguage::Jordan
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_lebanon_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_LEBANON).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_LEBANON).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_lebanon_as_lebanon_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_LEBANON).sub_language(), SubLanguage::Lebanon);
+        assert_eq!(
+            super::from_lang_id(ARABIC_LEBANON).sub_language(),
+            SubLanguage::Lebanon
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_kuwait_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_KUWAIT).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_KUWAIT).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_kuwait_as_kuwait_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_KUWAIT).sub_language(), SubLanguage::Kuwait);
+        assert_eq!(
+            super::from_lang_id(ARABIC_KUWAIT).sub_language(),
+            SubLanguage::Kuwait
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_uae_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_UAE).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_UAE).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_uae_as_uae_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_UAE).sub_language(), SubLanguage::UnitedArabEmirates);
+        assert_eq!(
+            super::from_lang_id(ARABIC_UAE).sub_language(),
+            SubLanguage::UnitedArabEmirates
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_bahrain_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_BAHRAIN).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_BAHRAIN).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_bahrain_as_bahrain_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_BAHRAIN).sub_language(), SubLanguage::Bahrain);
+        assert_eq!(
+            super::from_lang_id(ARABIC_BAHRAIN).sub_language(),
+            SubLanguage::Bahrain
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_qatar_as_arabic_language() {
-        assert_eq!(super::from_lang_id(ARABIC_QATAR).primary_language(), PrimaryLanguage::Arabic);
+        assert_eq!(
+            super::from_lang_id(ARABIC_QATAR).primary_language(),
+            PrimaryLanguage::Arabic
+        );
     }
 
     #[test]
     fn it_recognizes_arabic_from_qatar_as_qatar_sub_language() {
-        assert_eq!(super::from_lang_id(ARABIC_QATAR).sub_language(), SubLanguage::Qatar);
+        assert_eq!(
+            super::from_lang_id(ARABIC_QATAR).sub_language(),
+            SubLanguage::Qatar
+        );
     }
 
     #[test]
     fn it_recognizes_armenian_as_armenian_language() {
-        assert_eq!(super::from_lang_id(ARMENIAN).primary_language(), PrimaryLanguage::Armenian);
+        assert_eq!(
+            super::from_lang_id(ARMENIAN).primary_language(),
+            PrimaryLanguage::Armenian
+        );
     }
 
     #[test]
     fn it_recognizes_assamese_as_assamese_language() {
-        assert_eq!(super::from_lang_id(ASSAMESE).primary_language(), PrimaryLanguage::Assamese);
+        assert_eq!(
+            super::from_lang_id(ASSAMESE).primary_language(),
+            PrimaryLanguage::Assamese
+        );
     }
 
     #[test]
     fn it_recognizes_azeri_latin_as_azeri_language() {
-        assert_eq!(super::from_lang_id(AZERI_LATIN).primary_language(), PrimaryLanguage::Azeri);
+        assert_eq!(
+            super::from_lang_id(AZERI_LATIN).primary_language(),
+            PrimaryLanguage::Azeri
+        );
     }
 
     #[test]
     fn it_recognizes_azeri_latin_as_latin_sub_language() {
-        assert_eq!(super::from_lang_id(AZERI_LATIN).sub_language(), SubLanguage::Latin);
+        assert_eq!(
+            super::from_lang_id(AZERI_LATIN).sub_language(),
+            SubLanguage::Latin
+        );
     }
 
     #[test]
     fn it_recognizes_azeri_cyrillic_as_azeri_language() {
-        assert_eq!(super::from_lang_id(AZERI_CYRILLIC).primary_language(), PrimaryLanguage::Azeri);
+        assert_eq!(
+            super::from_lang_id(AZERI_CYRILLIC).primary_language(),
+            PrimaryLanguage::Azeri
+        );
     }
 
     #[test]
     fn it_recognizes_azeri_cyrillic_as_cyrillic_sub_language() {
-        assert_eq!(super::from_lang_id(AZERI_CYRILLIC).sub_language(), SubLanguage::Cyrillic);
+        assert_eq!(
+            super::from_lang_id(AZERI_CYRILLIC).sub_language(),
+            SubLanguage::Cyrillic
+        );
     }
 
     #[test]
     fn it_recognizes_basque_as_basque_language() {
-        assert_eq!(super::from_lang_id(BASQUE).primary_language(), PrimaryLanguage::Basque);
+        assert_eq!(
+            super::from_lang_id(BASQUE).primary_language(),
+            PrimaryLanguage::Basque
+        );
     }
 
     #[test]
     fn it_recognizes_belarussian_as_belarussian_language() {
-        assert_eq!(super::from_lang_id(BELARUSSIAN).primary_language(), PrimaryLanguage::Belarussian);
+        assert_eq!(
+            super::from_lang_id(BELARUSSIAN).primary_language(),
+            PrimaryLanguage::Belarussian
+        );
     }
 
     #[test]
     fn it_recognizes_bengali_as_bengali_language() {
-        assert_eq!(super::from_lang_id(BENGALI).primary_language(), PrimaryLanguage::Bengali);
+        assert_eq!(
+            super::from_lang_id(BENGALI).primary_language(),
+            PrimaryLanguage::Bengali
+        );
     }
 
     #[test]
     fn it_recognizes_bulgarian_as_bulgarian_language() {
-        assert_eq!(super::from_lang_id(BULGARIAN).primary_language(), PrimaryLanguage::Bulgarian);
+        assert_eq!(
+            super::from_lang_id(BULGARIAN).primary_language(),
+            PrimaryLanguage::Bulgarian
+        );
     }
 
     #[test]
     fn it_recognizes_burmese_as_burmese_language() {
-        assert_eq!(super::from_lang_id(BURMESE).primary_language(), PrimaryLanguage::Burmese);
+        assert_eq!(
+            super::from_lang_id(BURMESE).primary_language(),
+            PrimaryLanguage::Burmese
+        );
     }
 
     #[test]
     fn it_recognizes_catalan_as_catalan_language() {
-        assert_eq!(super::from_lang_id(CATALAN).primary_language(), PrimaryLanguage::Catalan);
+        assert_eq!(
+            super::from_lang_id(CATALAN).primary_language(),
+            PrimaryLanguage::Catalan
+        );
     }
 
     #[test]
     fn it_recognizes_chinese_from_taiwan_as_chinese_language() {
-        assert_eq!(super::from_lang_id(CHINESE_TAIWAN).primary_language(), PrimaryLanguage::Chinese);
+        assert_eq!(
+            super::from_lang_id(CHINESE_TAIWAN).primary_language(),
+            PrimaryLanguage::Chinese
+        );
     }
 
     #[test]
     fn it_recognizes_chinese_from_taiwan_as_taiwan_sub_language() {
-        assert_eq!(super::from_lang_id(CHINESE_TAIWAN).sub_language(), SubLanguage::Taiwan);
+        assert_eq!(
+            super::from_lang_id(CHINESE_TAIWAN).sub_language(),
+            SubLanguage::Taiwan
+        );
     }
 
     #[test]
     fn it_recognizes_chinese_from_china_as_chinese_language() {
-        assert_eq!(super::from_lang_id(CHINESE_CHINA).primary_language(), PrimaryLanguage::Chinese);
+        assert_eq!(
+            super::from_lang_id(CHINESE_CHINA).primary_language(),
+            PrimaryLanguage::Chinese
+        );
     }
 
     #[test]
     fn it_recognizes_chinese_from_china_as_china_sub_language() {
-        assert_eq!(super::from_lang_id(CHINESE_CHINA).sub_language(), SubLanguage::China);
+        assert_eq!(
+            super::from_lang_id(CHINESE_CHINA).sub_language(),
+            SubLanguage::China
+        );
     }
 
     #[test]
     fn it_recognizes_chinese_from_hong_kong_as_chinese_language() {
-        assert_eq!(super::from_lang_id(CHINESE_HONG_KONG).primary_language(), PrimaryLanguage::Chinese);
+        assert_eq!(
+            super::from_lang_id(CHINESE_HONG_KONG).primary_language(),
+            PrimaryLanguage::Chinese
+        );
     }
 
     #[test]
     fn it_recognizes_chinese_from_hong_kong_as_hong_kong_sub_language() {
-        assert_eq!(super::from_lang_id(CHINESE_HONG_KONG).sub_language(), SubLanguage::HongKong);
+        assert_eq!(
+            super::from_lang_id(CHINESE_HONG_KONG).sub_language(),
+            SubLanguage::HongKong
+        );
     }
 
     #[test]
     fn it_recognizes_chinese_from_singapore_as_chinese_language() {
-        assert_eq!(super::from_lang_id(CHINESE_SINGAPORE).primary_language(), PrimaryLanguage::Chinese);
+        assert_eq!(
+            super::from_lang_id(CHINESE_SINGAPORE).primary_language(),
+            PrimaryLanguage::Chinese
+        );
     }
 
     #[test]
     fn it_recognizes_chinese_from_singapore_as_singapore_sub_language() {
-        assert_eq!(super::from_lang_id(CHINESE_SINGAPORE).sub_language(), SubLanguage::Singapore);
+        assert_eq!(
+            super::from_lang_id(CHINESE_SINGAPORE).sub_language(),
+            SubLanguage::Singapore
+        );
     }
 
     #[test]
     fn it_recognizes_chinese_from_macau_as_chinese_language() {
-        assert_eq!(super::from_lang_id(CHINESE_MACAU).primary_language(), PrimaryLanguage::Chinese);
+        assert_eq!(
+            super::from_lang_id(CHINESE_MACAU).primary_language(),
+            PrimaryLanguage::Chinese
+        );
     }
 
     #[test]
     fn it_recognizes_chinese_from_macau_as_macau_sub_language() {
-        assert_eq!(super::from_lang_id(CHINESE_MACAU).sub_language(), SubLanguage::Macau);
+        assert_eq!(
+            super::from_lang_id(CHINESE_MACAU).sub_language(),
+            SubLanguage::Macau
+        );
     }
 
     #[test]
     fn it_recognizes_croatian_as_croatian_language() {
-        assert_eq!(super::from_lang_id(CROATIAN).primary_language(), PrimaryLanguage::Croatian);
+        assert_eq!(
+            super::from_lang_id(CROATIAN).primary_language(),
+            PrimaryLanguage::Croatian
+        );
     }
 
     #[test]
     fn it_recognizes_czech_as_czech_language() {
-        assert_eq!(super::from_lang_id(CZECH).primary_language(), PrimaryLanguage::Czech);
+        assert_eq!(
+            super::from_lang_id(CZECH).primary_language(),
+            PrimaryLanguage::Czech
+        );
     }
 
     #[test]
     fn it_recognizes_danish_as_danish_language() {
-        assert_eq!(super::from_lang_id(DANISH).primary_language(), PrimaryLanguage::Danish);
+        assert_eq!(
+            super::from_lang_id(DANISH).primary_language(),
+            PrimaryLanguage::Danish
+        );
     }
 
     #[test]
     fn it_recognizes_dutch_from_netherlands_as_dutch_language() {
-        assert_eq!(super::from_lang_id(DUTCH_NETHERLANDS).primary_language(), PrimaryLanguage::Dutch);
+        assert_eq!(
+            super::from_lang_id(DUTCH_NETHERLANDS).primary_language(),
+            PrimaryLanguage::Dutch
+        );
     }
 
     #[test]
     fn it_recognizes_dutch_from_netherlands_as_netherlands_sub_language() {
-        assert_eq!(super::from_lang_id(DUTCH_NETHERLANDS).sub_language(), SubLanguage::Netherlands);
+        assert_eq!(
+            super::from_lang_id(DUTCH_NETHERLANDS).sub_language(),
+            SubLanguage::Netherlands
+        );
     }
 
     #[test]
     fn it_recognizes_dutch_from_belgium_as_dutch_language() {
-        assert_eq!(super::from_lang_id(DUTCH_BELGIUM).primary_language(), PrimaryLanguage::Dutch);
+        assert_eq!(
+            super::from_lang_id(DUTCH_BELGIUM).primary_language(),
+            PrimaryLanguage::Dutch
+        );
     }
 
     #[test]
     fn it_recognizes_dutch_from_belgium_as_belgium_sub_language() {
-        assert_eq!(super::from_lang_id(DUTCH_BELGIUM).sub_language(), SubLanguage::Belgium);
+        assert_eq!(
+            super::from_lang_id(DUTCH_BELGIUM).sub_language(),
+            SubLanguage::Belgium
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_united_states_as_english_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_UNITED_STATES).primary_language(), PrimaryLanguage::English);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_UNITED_STATES).primary_language(),
+            PrimaryLanguage::English
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_united_states_as_united_states_sub_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_UNITED_STATES).sub_language(), SubLanguage::UnitedStates);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_UNITED_STATES).sub_language(),
+            SubLanguage::UnitedStates
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_united_kingdom_as_english_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_UNITED_KINGDOM).primary_language(), PrimaryLanguage::English);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_UNITED_KINGDOM).primary_language(),
+            PrimaryLanguage::English
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_united_kingdom_as_united_kingdom_sub_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_UNITED_KINGDOM).sub_language(), SubLanguage::UnitedKingdom);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_UNITED_KINGDOM).sub_language(),
+            SubLanguage::UnitedKingdom
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_australia_as_english_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_AUSTRALIAN).primary_language(), PrimaryLanguage::English);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_AUSTRALIAN).primary_language(),
+            PrimaryLanguage::English
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_australia_as_australia_sub_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_AUSTRALIAN).sub_language(), SubLanguage::Australia);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_AUSTRALIAN).sub_language(),
+            SubLanguage::Australia
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_canada_as_english_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_CANADIAN).primary_language(), PrimaryLanguage::English);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_CANADIAN).primary_language(),
+            PrimaryLanguage::English
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_canada_as_canada_sub_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_CANADIAN).sub_language(), SubLanguage::Canada);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_CANADIAN).sub_language(),
+            SubLanguage::Canada
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_new_zealand_as_english_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_NEW_ZEALAND).primary_language(), PrimaryLanguage::English);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_NEW_ZEALAND).primary_language(),
+            PrimaryLanguage::English
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_new_zealand_as_new_zealand_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_NEW_ZEALAND).sub_language(), SubLanguage::NewZealand);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_NEW_ZEALAND).sub_language(),
+            SubLanguage::NewZealand
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_ireland_as_english_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_IRELAND).primary_language(), PrimaryLanguage::English);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_IRELAND).primary_language(),
+            PrimaryLanguage::English
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_ireland_as_ireland_sub_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_IRELAND).sub_language(), SubLanguage::Ireland);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_IRELAND).sub_language(),
+            SubLanguage::Ireland
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_south_africa_as_english_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_SOUTH_AFRICA).primary_language(), PrimaryLanguage::English);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_SOUTH_AFRICA).primary_language(),
+            PrimaryLanguage::English
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_south_africa_as_south_africa_sub_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_SOUTH_AFRICA).sub_language(), SubLanguage::SouthAfrica);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_SOUTH_AFRICA).sub_language(),
+            SubLanguage::SouthAfrica
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_jamaica_as_english_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_JAMAICA).primary_language(), PrimaryLanguage::English);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_JAMAICA).primary_language(),
+            PrimaryLanguage::English
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_jamaica_as_jamaica_sub_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_JAMAICA).sub_language(), SubLanguage::Jamaica);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_JAMAICA).sub_language(),
+            SubLanguage::Jamaica
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_caribbean_as_english_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_CARIBBEAN).primary_language(), PrimaryLanguage::English);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_CARIBBEAN).primary_language(),
+            PrimaryLanguage::English
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_caribbean_as_caribbean_sub_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_CARIBBEAN).sub_language(), SubLanguage::Caribbean);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_CARIBBEAN).sub_language(),
+            SubLanguage::Caribbean
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_belize_as_english_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_BELIZE).primary_language(), PrimaryLanguage::English);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_BELIZE).primary_language(),
+            PrimaryLanguage::English
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_belize_as_belize_sub_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_BELIZE).sub_language(), SubLanguage::Belize);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_BELIZE).sub_language(),
+            SubLanguage::Belize
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_trinidad_as_english_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_TRINIDAD).primary_language(), PrimaryLanguage::English);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_TRINIDAD).primary_language(),
+            PrimaryLanguage::English
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_trinidad_as_trinidad_sub_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_TRINIDAD).sub_language(), SubLanguage::Trinidad);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_TRINIDAD).sub_language(),
+            SubLanguage::Trinidad
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_zimbabwe_as_english_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_ZIMBABWE).primary_language(), PrimaryLanguage::English);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_ZIMBABWE).primary_language(),
+            PrimaryLanguage::English
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_zimbabwe_as_zimbabwe_sub_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_ZIMBABWE).sub_language(), SubLanguage::Zimbabwe);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_ZIMBABWE).sub_language(),
+            SubLanguage::Zimbabwe
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_philippines_as_english_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_PHILIPPINES).primary_language(), PrimaryLanguage::English);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_PHILIPPINES).primary_language(),
+            PrimaryLanguage::English
+        );
     }
 
     #[test]
     fn it_recognizes_english_from_philippines_as_philippines_sub_language() {
-        assert_eq!(super::from_lang_id(ENGLISH_PHILIPPINES).sub_language(), SubLanguage::Philippines);
+        assert_eq!(
+            super::from_lang_id(ENGLISH_PHILIPPINES).sub_language(),
+            SubLanguage::Philippines
+        );
     }
 
     #[test]
     fn it_recognizes_estonian_as_estonian_language() {
-        assert_eq!(super::from_lang_id(ESTONIAN).primary_language(), PrimaryLanguage::Estonian);
+        assert_eq!(
+            super::from_lang_id(ESTONIAN).primary_language(),
+            PrimaryLanguage::Estonian
+        );
     }
 
     #[test]
     fn it_recognizes_faeroese_as_faeroese_language() {
-        assert_eq!(super::from_lang_id(FAEROESE).primary_language(), PrimaryLanguage::Faeroese);
+        assert_eq!(
+            super::from_lang_id(FAEROESE).primary_language(),
+            PrimaryLanguage::Faeroese
+        );
     }
 
     #[test]
     fn it_recognizes_farsi_as_farsi_language() {
-        assert_eq!(super::from_lang_id(FARSI).primary_language(), PrimaryLanguage::Farsi);
+        assert_eq!(
+            super::from_lang_id(FARSI).primary_language(),
+            PrimaryLanguage::Farsi
+        );
     }
 
     #[test]
     fn it_recognizes_finnish_as_finnish_language() {
-        assert_eq!(super::from_lang_id(FINNISH).primary_language(), PrimaryLanguage::Finnish);
+        assert_eq!(
+            super::from_lang_id(FINNISH).primary_language(),
+            PrimaryLanguage::Finnish
+        );
     }
 
     #[test]
     fn it_recognizes_french_standard_as_french_language() {
-        assert_eq!(super::from_lang_id(FRENCH_STANDARD).primary_language(), PrimaryLanguage::French);
+        assert_eq!(
+            super::from_lang_id(FRENCH_STANDARD).primary_language(),
+            PrimaryLanguage::French
+        );
     }
 
     #[test]
     fn it_recognizes_french_standard_as_standard_sub_language() {
-        assert_eq!(super::from_lang_id(FRENCH_STANDARD).sub_language(), SubLanguage::Standard);
+        assert_eq!(
+            super::from_lang_id(FRENCH_STANDARD).sub_language(),
+            SubLanguage::Standard
+        );
     }
 
     #[test]
     fn it_recognizes_french_from_belgium_as_french_language() {
-        assert_eq!(super::from_lang_id(FRENCH_BELGIAN).primary_language(), PrimaryLanguage::French);
+        assert_eq!(
+            super::from_lang_id(FRENCH_BELGIAN).primary_language(),
+            PrimaryLanguage::French
+        );
     }
 
     #[test]
     fn it_recognizes_french_from_belgium_as_belgium_sub_language() {
-        assert_eq!(super::from_lang_id(FRENCH_BELGIAN).sub_language(), SubLanguage::Belgium);
+        assert_eq!(
+            super::from_lang_id(FRENCH_BELGIAN).sub_language(),
+            SubLanguage::Belgium
+        );
     }
 
     #[test]
     fn it_recognizes_french_from_canada_as_french_language() {
-        assert_eq!(super::from_lang_id(FRENCH_CANADIAN).primary_language(), PrimaryLanguage::French);
+        assert_eq!(
+            super::from_lang_id(FRENCH_CANADIAN).primary_language(),
+            PrimaryLanguage::French
+        );
     }
 
     #[test]
     fn it_recognizes_french_from_canada_as_canada_sub_language() {
-        assert_eq!(super::from_lang_id(FRENCH_CANADIAN).sub_language(), SubLanguage::Canada);
+        assert_eq!(
+            super::from_lang_id(FRENCH_CANADIAN).sub_language(),
+            SubLanguage::Canada
+        );
     }
 
     #[test]
     fn it_recognizes_french_from_switzerland_as_french_language() {
-        assert_eq!(super::from_lang_id(FRENCH_SWITZERLAND).primary_language(), PrimaryLanguage::French);
+        assert_eq!(
+            super::from_lang_id(FRENCH_SWITZERLAND).primary_language(),
+            PrimaryLanguage::French
+        );
     }
 
     #[test]
     fn it_recognizes_french_from_switzerland_as_switzerland_sub_language() {
-        assert_eq!(super::from_lang_id(FRENCH_SWITZERLAND).sub_language(), SubLanguage::Switzerland);
+        assert_eq!(
+            super::from_lang_id(FRENCH_SWITZERLAND).sub_language(),
+            SubLanguage::Switzerland
+        );
     }
 
     #[test]
     fn it_recognizes_french_from_luxembourg_as_french_language() {
-        assert_eq!(super::from_lang_id(FRENCH_LUXEMBOURG).primary_language(), PrimaryLanguage::French);
+        assert_eq!(
+            super::from_lang_id(FRENCH_LUXEMBOURG).primary_language(),
+            PrimaryLanguage::French
+        );
     }
 
     #[test]
     fn it_recognizes_french_from_luxembourg_as_luxembourg_sub_language() {
-        assert_eq!(super::from_lang_id(FRENCH_LUXEMBOURG).sub_language(), SubLanguage::Luxembourg);
+        assert_eq!(
+            super::from_lang_id(FRENCH_LUXEMBOURG).sub_language(),
+            SubLanguage::Luxembourg
+        );
     }
 
     #[test]
     fn it_recognizes_french_from_monaco_as_french_language() {
-        assert_eq!(super::from_lang_id(FRENCH_MONACO).primary_language(), PrimaryLanguage::French);
+        assert_eq!(
+            super::from_lang_id(FRENCH_MONACO).primary_language(),
+            PrimaryLanguage::French
+        );
     }
 
     #[test]
     fn it_recognizes_french_from_monaco_as_monaco_sub_language() {
-        assert_eq!(super::from_lang_id(FRENCH_MONACO).sub_language(), SubLanguage::Monaco);
+        assert_eq!(
+            super::from_lang_id(FRENCH_MONACO).sub_language(),
+            SubLanguage::Monaco
+        );
     }
 
     #[test]
     fn it_recognizes_georgian_as_georgian_language() {
-        assert_eq!(super::from_lang_id(GEORGIAN).primary_language(), PrimaryLanguage::Georgian);
+        assert_eq!(
+            super::from_lang_id(GEORGIAN).primary_language(),
+            PrimaryLanguage::Georgian
+        );
     }
 
     #[test]
     fn it_recognizes_german_standard_as_german_language() {
-        assert_eq!(super::from_lang_id(GERMAN_STANDARD).primary_language(), PrimaryLanguage::German);
+        assert_eq!(
+            super::from_lang_id(GERMAN_STANDARD).primary_language(),
+            PrimaryLanguage::German
+        );
     }
 
     #[test]
     fn it_recognizes_german_standard_as_standard_sub_language() {
-        assert_eq!(super::from_lang_id(GERMAN_STANDARD).sub_language(), SubLanguage::Standard);
+        assert_eq!(
+            super::from_lang_id(GERMAN_STANDARD).sub_language(),
+            SubLanguage::Standard
+        );
     }
 
     #[test]
     fn it_recognizes_german_from_switzerland_as_german_language() {
-        assert_eq!(super::from_lang_id(GERMAN_SWITZERLAND).primary_language(), PrimaryLanguage::German);
+        assert_eq!(
+            super::from_lang_id(GERMAN_SWITZERLAND).primary_language(),
+            PrimaryLanguage::German
+        );
     }
 
     #[test]
     fn it_recognizes_german_from_switzerland_as_switzerland_sub_language() {
-        assert_eq!(super::from_lang_id(GERMAN_SWITZERLAND).sub_language(), SubLanguage::Switzerland);
+        assert_eq!(
+            super::from_lang_id(GERMAN_SWITZERLAND).sub_language(),
+            SubLanguage::Switzerland
+        );
     }
 
     #[test]
     fn it_recognizes_german_from_austria_as_german_language() {
-        assert_eq!(super::from_lang_id(GERMAN_AUSTRIA).primary_language(), PrimaryLanguage::German);
+        assert_eq!(
+            super::from_lang_id(GERMAN_AUSTRIA).primary_language(),
+            PrimaryLanguage::German
+        );
     }
 
     #[test]
     fn it_recognizes_german_from_austria_as_austria_sub_language() {
-        assert_eq!(super::from_lang_id(GERMAN_AUSTRIA).sub_language(), SubLanguage::Austria);
+        assert_eq!(
+            super::from_lang_id(GERMAN_AUSTRIA).sub_language(),
+            SubLanguage::Austria
+        );
     }
 
     #[test]
     fn it_recognizes_german_from_luxembourg_as_german_language() {
-        assert_eq!(super::from_lang_id(GERMAN_LUXEMBOURG).primary_language(), PrimaryLanguage::German);
+        assert_eq!(
+            super::from_lang_id(GERMAN_LUXEMBOURG).primary_language(),
+            PrimaryLanguage::German
+        );
     }
 
     #[test]
     fn it_recognizes_german_from_luxembourg_as_luxembourg_sub_language() {
-        assert_eq!(super::from_lang_id(GERMAN_LUXEMBOURG).sub_language(), SubLanguage::Luxembourg);
+        assert_eq!(
+            super::from_lang_id(GERMAN_LUXEMBOURG).sub_language(),
+            SubLanguage::Luxembourg
+        );
     }
 
     #[test]
     fn it_recognizes_german_from_liechtenstein_as_german_language() {
-        assert_eq!(super::from_lang_id(GERMAN_LIECHTENSTEIN).primary_language(), PrimaryLanguage::German);
+        assert_eq!(
+            super::from_lang_id(GERMAN_LIECHTENSTEIN).primary_language(),
+            PrimaryLanguage::German
+        );
     }
 
     #[test]
     fn it_recognizes_german_from_liechtenstein_as_liechtenstein_sub_language() {
-        assert_eq!(super::from_lang_id(GERMAN_LIECHTENSTEIN).sub_language(), SubLanguage::Liechtenstein);
+        assert_eq!(
+            super::from_lang_id(GERMAN_LIECHTENSTEIN).sub_language(),
+            SubLanguage::Liechtenstein
+        );
     }
 
     #[test]
     fn it_recognizes_greek_as_greek_language() {
-        assert_eq!(super::from_lang_id(GREEK).primary_language(), PrimaryLanguage::Greek);
+        assert_eq!(
+            super::from_lang_id(GREEK).primary_language(),
+            PrimaryLanguage::Greek
+        );
     }
 
     #[test]
     fn it_recognizes_gujarati_as_gujarati_language() {
-        assert_eq!(super::from_lang_id(GUJARATI).primary_language(), PrimaryLanguage::Gujarati);
+        assert_eq!(
+            super::from_lang_id(GUJARATI).primary_language(),
+            PrimaryLanguage::Gujarati
+        );
     }
 
     #[test]
     fn it_recognizes_hebrew_as_hebrew_language() {
-        assert_eq!(super::from_lang_id(HEBREW).primary_language(), PrimaryLanguage::Hebrew);
+        assert_eq!(
+            super::from_lang_id(HEBREW).primary_language(),
+            PrimaryLanguage::Hebrew
+        );
     }
 
     #[test]
     fn it_recognizes_hindi_as_hindi_language() {
-        assert_eq!(super::from_lang_id(HINDI).primary_language(), PrimaryLanguage::Hindi);
+        assert_eq!(
+            super::from_lang_id(HINDI).primary_language(),
+            PrimaryLanguage::Hindi
+        );
     }
 
     #[test]
     fn it_recognizes_hungarian_as_hungarian_language() {
-        assert_eq!(super::from_lang_id(HUNGARIAN).primary_language(), PrimaryLanguage::Hungarian);
+        assert_eq!(
+            super::from_lang_id(HUNGARIAN).primary_language(),
+            PrimaryLanguage::Hungarian
+        );
     }
 
     #[test]
     fn it_recognizes_icelandic_as_icelandic_language() {
-        assert_eq!(super::from_lang_id(ICELANDIC).primary_language(), PrimaryLanguage::Icelandic);
+        assert_eq!(
+            super::from_lang_id(ICELANDIC).primary_language(),
+            PrimaryLanguage::Icelandic
+        );
     }
 
     #[test]
     fn it_recognizes_indonesian_as_indonesian_language() {
-        assert_eq!(super::from_lang_id(INDONESIAN).primary_language(), PrimaryLanguage::Indonesian);
+        assert_eq!(
+            super::from_lang_id(INDONESIAN).primary_language(),
+            PrimaryLanguage::Indonesian
+        );
     }
 
     #[test]
     fn it_recognizes_italian_standard_as_italian_language() {
-        assert_eq!(super::from_lang_id(ITALIAN_STANDARD).primary_language(), PrimaryLanguage::Italian);
+        assert_eq!(
+            super::from_lang_id(ITALIAN_STANDARD).primary_language(),
+            PrimaryLanguage::Italian
+        );
     }
 
     #[test]
     fn it_recognizes_italian_standard_as_standard_sub_language() {
-        assert_eq!(super::from_lang_id(ITALIAN_STANDARD).sub_language(), SubLanguage::Standard);
+        assert_eq!(
+            super::from_lang_id(ITALIAN_STANDARD).sub_language(),
+            SubLanguage::Standard
+        );
     }
 
     #[test]
     fn it_recognizes_italian_from_switzerland_as_italian_language() {
-        assert_eq!(super::from_lang_id(ITALIAN_SWITZERLAND).primary_language(), PrimaryLanguage::Italian);
+        assert_eq!(
+            super::from_lang_id(ITALIAN_SWITZERLAND).primary_language(),
+            PrimaryLanguage::Italian
+        );
     }
 
     #[test]
     fn it_recognizes_italian_from_switzerland_as_switzerland_sub_language() {
-        assert_eq!(super::from_lang_id(ITALIAN_SWITZERLAND).sub_language(), SubLanguage::Switzerland);
+        assert_eq!(
+            super::from_lang_id(ITALIAN_SWITZERLAND).sub_language(),
+            SubLanguage::Switzerland
+        );
     }
 
     #[test]
     fn it_recognizes_japanese_as_japanese_language() {
-        assert_eq!(super::from_lang_id(JAPANESE).primary_language(), PrimaryLanguage::Japanese);
+        assert_eq!(
+            super::from_lang_id(JAPANESE).primary_language(),
+            PrimaryLanguage::Japanese
+        );
     }
 
     #[test]
     fn it_recognizes_kannada_as_kannada_language() {
-        assert_eq!(super::from_lang_id(KANNADA).primary_language(), PrimaryLanguage::Kannada);
+        assert_eq!(
+            super::from_lang_id(KANNADA).primary_language(),
+            PrimaryLanguage::Kannada
+        );
     }
 
     #[test]
     fn it_recognizes_kashmiri_as_kashmiri_language() {
-        assert_eq!(super::from_lang_id(KASHMIRI_INDIA).primary_language(), PrimaryLanguage::Kashmiri);
+        assert_eq!(
+            super::from_lang_id(KASHMIRI_INDIA).primary_language(),
+            PrimaryLanguage::Kashmiri
+        );
     }
 
     #[test]
     fn it_recognizes_kazakh_as_kazakh_language() {
-        assert_eq!(super::from_lang_id(KAZAKH).primary_language(), PrimaryLanguage::Kazakh);
+        assert_eq!(
+            super::from_lang_id(KAZAKH).primary_language(),
+            PrimaryLanguage::Kazakh
+        );
     }
 
     #[test]
     fn it_recognizes_konkani_as_konkani_language() {
-        assert_eq!(super::from_lang_id(KONKANI).primary_language(), PrimaryLanguage::Konkani);
+        assert_eq!(
+            super::from_lang_id(KONKANI).primary_language(),
+            PrimaryLanguage::Konkani
+        );
     }
 
     #[test]
     fn it_recognizes_korean_as_korean_language() {
-        assert_eq!(super::from_lang_id(KOREAN).primary_language(), PrimaryLanguage::Korean);
+        assert_eq!(
+            super::from_lang_id(KOREAN).primary_language(),
+            PrimaryLanguage::Korean
+        );
     }
 
     #[test]
     fn it_recognizes_korean_as_standard_sub_language() {
-        assert_eq!(super::from_lang_id(KOREAN).sub_language(), SubLanguage::Standard);
+        assert_eq!(
+            super::from_lang_id(KOREAN).sub_language(),
+            SubLanguage::Standard
+        );
     }
 
     #[test]
     fn it_recognizes_korean_johab_as_korean_language() {
-        assert_eq!(super::from_lang_id(KOREAN_JOHAB).primary_language(), PrimaryLanguage::Korean);
+        assert_eq!(
+            super::from_lang_id(KOREAN_JOHAB).primary_language(),
+            PrimaryLanguage::Korean
+        );
     }
 
     #[test]
     fn it_recognizes_korean_johab_as_johab_sub_language() {
-        assert_eq!(super::from_lang_id(KOREAN_JOHAB).sub_language(), SubLanguage::Johab);
+        assert_eq!(
+            super::from_lang_id(KOREAN_JOHAB).sub_language(),
+            SubLanguage::Johab
+        );
     }
 
     #[test]
     fn it_recognizes_latvian_as_latvian_language() {
-        assert_eq!(super::from_lang_id(LATVIAN).primary_language(), PrimaryLanguage::Latvian);
+        assert_eq!(
+            super::from_lang_id(LATVIAN).primary_language(),
+            PrimaryLanguage::Latvian
+        );
     }
 
     #[test]
     fn it_recognizes_lithuanian_as_lithuanian_language() {
-        assert_eq!(super::from_lang_id(LITHUANIAN).primary_language(), PrimaryLanguage::Lithuanian);
+        assert_eq!(
+            super::from_lang_id(LITHUANIAN).primary_language(),
+            PrimaryLanguage::Lithuanian
+        );
     }
 
     #[test]
     fn it_recognizes_lithuanian_as_standard_sub_language() {
-        assert_eq!(super::from_lang_id(LITHUANIAN).sub_language(), SubLanguage::Standard);
+        assert_eq!(
+            super::from_lang_id(LITHUANIAN).sub_language(),
+            SubLanguage::Standard
+        );
     }
 
     #[test]
     fn it_recognizes_lithuanian_classic_as_lithuanian_language() {
-        assert_eq!(super::from_lang_id(LITHUANIAN_CLASSIC).primary_language(), PrimaryLanguage::Lithuanian);
+        assert_eq!(
+            super::from_lang_id(LITHUANIAN_CLASSIC).primary_language(),
+            PrimaryLanguage::Lithuanian
+        );
     }
 
     #[test]
     fn it_recognizes_lithuanian_classic_as_classic_sub_language() {
-        assert_eq!(super::from_lang_id(LITHUANIAN_CLASSIC).sub_language(), SubLanguage::Classic);
+        assert_eq!(
+            super::from_lang_id(LITHUANIAN_CLASSIC).sub_language(),
+            SubLanguage::Classic
+        );
     }
 
     #[test]
     fn it_recognizes_macedonian_as_macedonian_language() {
-        assert_eq!(super::from_lang_id(MACEDONIAN).primary_language(), PrimaryLanguage::Macedonian);
+        assert_eq!(
+            super::from_lang_id(MACEDONIAN).primary_language(),
+            PrimaryLanguage::Macedonian
+        );
     }
 
     #[test]
     fn it_recognizes_malay_from_malaysia_as_malay_language() {
-        assert_eq!(super::from_lang_id(MALAY_MALAYSIAN).primary_language(), PrimaryLanguage::Malay);
+        assert_eq!(
+            super::from_lang_id(MALAY_MALAYSIAN).primary_language(),
+            PrimaryLanguage::Malay
+        );
     }
 
     #[test]
     fn it_recognizes_malay_from_malaysia_as_malaysia_sub_language() {
-        assert_eq!(super::from_lang_id(MALAY_MALAYSIAN).sub_language(), SubLanguage::Malaysia);
+        assert_eq!(
+            super::from_lang_id(MALAY_MALAYSIAN).sub_language(),
+            SubLanguage::Malaysia
+        );
     }
 
     #[test]
     fn it_recognizes_malay_from_brunei_darussalam_as_malay_language() {
-        assert_eq!(super::from_lang_id(MALAY_BRUNEI_DARUSSALAM).primary_language(), PrimaryLanguage::Malay);
+        assert_eq!(
+            super::from_lang_id(MALAY_BRUNEI_DARUSSALAM).primary_language(),
+            PrimaryLanguage::Malay
+        );
     }
 
     #[test]
     fn it_recognizes_malay_from_brunei_darussalam_as_brunei_darussalam_sub_language() {
-        assert_eq!(super::from_lang_id(MALAY_BRUNEI_DARUSSALAM).sub_language(), SubLanguage::BruneiDarussalam);
+        assert_eq!(
+            super::from_lang_id(MALAY_BRUNEI_DARUSSALAM).sub_language(),
+            SubLanguage::BruneiDarussalam
+        );
     }
 
     #[test]
     fn it_recognizes_malayalam_as_malayalam_language() {
-        assert_eq!(super::from_lang_id(MALAYALAM).primary_language(), PrimaryLanguage::Malayalam);
+        assert_eq!(
+            super::from_lang_id(MALAYALAM).primary_language(),
+            PrimaryLanguage::Malayalam
+        );
     }
 
     #[test]
     fn it_recognizes_manipuri_as_manipuri_language() {
-        assert_eq!(super::from_lang_id(MANIPURI).primary_language(), PrimaryLanguage::Manipuri);
+        assert_eq!(
+            super::from_lang_id(MANIPURI).primary_language(),
+            PrimaryLanguage::Manipuri
+        );
     }
 
     #[test]
     fn it_recognizes_marathi_as_marathi_language() {
-        assert_eq!(super::from_lang_id(MARATHI).primary_language(), PrimaryLanguage::Marathi);
+        assert_eq!(
+            super::from_lang_id(MARATHI).primary_language(),
+            PrimaryLanguage::Marathi
+        );
     }
 
     #[test]
     fn it_recognizes_nepali_as_nepali_language() {
-        assert_eq!(super::from_lang_id(NEPALI_INDIA).primary_language(), PrimaryLanguage::Nepali);
+        assert_eq!(
+            super::from_lang_id(NEPALI_INDIA).primary_language(),
+            PrimaryLanguage::Nepali
+        );
     }
 
     #[test]
     fn it_recognizes_norwegian_bokmal_as_norwegian_language() {
-        assert_eq!(super::from_lang_id(NORWEGIAN_BOKMAL).primary_language(), PrimaryLanguage::Norwegian);
+        assert_eq!(
+            super::from_lang_id(NORWEGIAN_BOKMAL).primary_language(),
+            PrimaryLanguage::Norwegian
+        );
     }
 
     #[test]
     fn it_recognizes_norwegian_bokmal_as_bokmal_sub_language() {
-        assert_eq!(super::from_lang_id(NORWEGIAN_BOKMAL).sub_language(), SubLanguage::Bokmal);
+        assert_eq!(
+            super::from_lang_id(NORWEGIAN_BOKMAL).sub_language(),
+            SubLanguage::Bokmal
+        );
     }
 
     #[test]
     fn it_recognizes_norwegian_nynorsk_as_norwegian_language() {
-        assert_eq!(super::from_lang_id(NORWEGIAN_NYNORSK).primary_language(), PrimaryLanguage::Norwegian);
+        assert_eq!(
+            super::from_lang_id(NORWEGIAN_NYNORSK).primary_language(),
+            PrimaryLanguage::Norwegian
+        );
     }
 
     #[test]
     fn it_recognizes_norwegian_nynorsk_as_nynorsk_sub_language() {
-        assert_eq!(super::from_lang_id(NORWEGIAN_NYNORSK).sub_language(), SubLanguage::Nynorsk);
+        assert_eq!(
+            super::from_lang_id(NORWEGIAN_NYNORSK).sub_language(),
+            SubLanguage::Nynorsk
+        );
     }
 
     #[test]
     fn it_recognizes_oriya_as_oriya_language() {
-        assert_eq!(super::from_lang_id(ORIYA).primary_language(), PrimaryLanguage::Oriya);
+        assert_eq!(
+            super::from_lang_id(ORIYA).primary_language(),
+            PrimaryLanguage::Oriya
+        );
     }
 
     #[test]
     fn it_recognizes_polish_as_polish_language() {
-        assert_eq!(super::from_lang_id(POLISH).primary_language(), PrimaryLanguage::Polish);
+        assert_eq!(
+            super::from_lang_id(POLISH).primary_language(),
+            PrimaryLanguage::Polish
+        );
     }
 
     #[test]
     fn it_recognizes_portuguese_from_brazil_as_portuguese_language() {
-        assert_eq!(super::from_lang_id(PORTUGUESE_BRAZIL).primary_language(), PrimaryLanguage::Portuguese);
+        assert_eq!(
+            super::from_lang_id(PORTUGUESE_BRAZIL).primary_language(),
+            PrimaryLanguage::Portuguese
+        );
     }
 
     #[test]
     fn it_recognizes_portuguese_from_brazil_as_brazil_sub_language() {
-        assert_eq!(super::from_lang_id(PORTUGUESE_BRAZIL).sub_language(), SubLanguage::Brazil);
+        assert_eq!(
+            super::from_lang_id(PORTUGUESE_BRAZIL).sub_language(),
+            SubLanguage::Brazil
+        );
     }
 
     #[test]
     fn it_recognizes_portuguese_standard_as_portuguese_language() {
-        assert_eq!(super::from_lang_id(PORTUGUESE_STANDARD).primary_language(), PrimaryLanguage::Portuguese);
+        assert_eq!(
+            super::from_lang_id(PORTUGUESE_STANDARD).primary_language(),
+            PrimaryLanguage::Portuguese
+        );
     }
 
     #[test]
     fn it_recognizes_portuguese_standard_as_standard_sub_language() {
-        assert_eq!(super::from_lang_id(PORTUGUESE_STANDARD).sub_language(), SubLanguage::Standard);
+        assert_eq!(
+            super::from_lang_id(PORTUGUESE_STANDARD).sub_language(),
+            SubLanguage::Standard
+        );
     }
 
     #[test]
     fn it_recognizes_punjabi_as_punjabi_language() {
-        assert_eq!(super::from_lang_id(PUNJABI).primary_language(), PrimaryLanguage::Punjabi);
+        assert_eq!(
+            super::from_lang_id(PUNJABI).primary_language(),
+            PrimaryLanguage::Punjabi
+        );
     }
 
     #[test]
     fn it_recognizes_romanian_as_romanian_language() {
-        assert_eq!(super::from_lang_id(ROMANIAN).primary_language(), PrimaryLanguage::Romanian);
+        assert_eq!(
+            super::from_lang_id(ROMANIAN).primary_language(),
+            PrimaryLanguage::Romanian
+        );
     }
 
     #[test]
     fn it_recognizes_russian_as_russian_language() {
-        assert_eq!(super::from_lang_id(RUSSIAN).primary_language(), PrimaryLanguage::Russian);
+        assert_eq!(
+            super::from_lang_id(RUSSIAN).primary_language(),
+            PrimaryLanguage::Russian
+        );
     }
 
     #[test]
     fn it_recognizes_sanskrit_as_sanskrit_language() {
-        assert_eq!(super::from_lang_id(SANSKRIT).primary_language(), PrimaryLanguage::Sanskrit);
+        assert_eq!(
+            super::from_lang_id(SANSKRIT).primary_language(),
+            PrimaryLanguage::Sanskrit
+        );
     }
 
     #[test]
     fn it_recognizes_serbian_cyrillic_as_serbian_language() {
-        assert_eq!(super::from_lang_id(SERBIAN_CYRILLIC).primary_language(), PrimaryLanguage::Serbian);
+        assert_eq!(
+            super::from_lang_id(SERBIAN_CYRILLIC).primary_language(),
+            PrimaryLanguage::Serbian
+        );
     }
 
     #[test]
     fn it_recognizes_serbian_cyrillic_as_cyrillic_sub_language() {
-        assert_eq!(super::from_lang_id(SERBIAN_CYRILLIC).sub_language(), SubLanguage::Cyrillic);
+        assert_eq!(
+            super::from_lang_id(SERBIAN_CYRILLIC).sub_language(),
+            SubLanguage::Cyrillic
+        );
     }
 
     #[test]
     fn it_recognizes_serbian_latin_as_serbian_language() {
-        assert_eq!(super::from_lang_id(SERBIAN_LATIN).primary_language(), PrimaryLanguage::Serbian);
+        assert_eq!(
+            super::from_lang_id(SERBIAN_LATIN).primary_language(),
+            PrimaryLanguage::Serbian
+        );
     }
 
     #[test]
     fn it_recognizes_serbian_latin_as_latin_sub_language() {
-        assert_eq!(super::from_lang_id(SERBIAN_LATIN).sub_language(), SubLanguage::Latin);
+        assert_eq!(
+            super::from_lang_id(SERBIAN_LATIN).sub_language(),
+            SubLanguage::Latin
+        );
     }
 
     #[test]
     fn it_recognizes_sindhi_as_sindhi_language() {
-        assert_eq!(super::from_lang_id(SINDHI).primary_language(), PrimaryLanguage::Sindhi);
+        assert_eq!(
+            super::from_lang_id(SINDHI).primary_language(),
+            PrimaryLanguage::Sindhi
+        );
     }
 
     #[test]
     fn it_recognizes_slovak_as_slovak_language() {
-        assert_eq!(super::from_lang_id(SLOVAK).primary_language(), PrimaryLanguage::Slovak);
+        assert_eq!(
+            super::from_lang_id(SLOVAK).primary_language(),
+            PrimaryLanguage::Slovak
+        );
     }
 
     #[test]
     fn it_recognizes_slovenian_as_slovenian_language() {
-        assert_eq!(super::from_lang_id(SLOVENIAN).primary_language(), PrimaryLanguage::Slovenian);
+        assert_eq!(
+            super::from_lang_id(SLOVENIAN).primary_language(),
+            PrimaryLanguage::Slovenian
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_traditional_sort_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_TRADITIONAL_SORT).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_TRADITIONAL_SORT).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_traditional_sort_as_traditional_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_TRADITIONAL_SORT).sub_language(), SubLanguage::Traditional);
+        assert_eq!(
+            super::from_lang_id(SPANISH_TRADITIONAL_SORT).sub_language(),
+            SubLanguage::Traditional
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_mexico_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_MEXICAN).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_MEXICAN).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_mexico_as_mexico_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_MEXICAN).sub_language(), SubLanguage::Mexico);
+        assert_eq!(
+            super::from_lang_id(SPANISH_MEXICAN).sub_language(),
+            SubLanguage::Mexico
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_modern_sort_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_MODERN_SORT).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_MODERN_SORT).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_modern_sort_as_modern_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_MODERN_SORT).sub_language(), SubLanguage::Modern);
+        assert_eq!(
+            super::from_lang_id(SPANISH_MODERN_SORT).sub_language(),
+            SubLanguage::Modern
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_guatemala_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_GUATEMALA).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_GUATEMALA).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_guatemala_as_guatemala_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_GUATEMALA).sub_language(), SubLanguage::Guatemala);
+        assert_eq!(
+            super::from_lang_id(SPANISH_GUATEMALA).sub_language(),
+            SubLanguage::Guatemala
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_costa_rica_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_COSTA_RICA).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_COSTA_RICA).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_costa_rica_as_costa_rica_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_COSTA_RICA).sub_language(), SubLanguage::CostaRica);
+        assert_eq!(
+            super::from_lang_id(SPANISH_COSTA_RICA).sub_language(),
+            SubLanguage::CostaRica
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_panama_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_PANAMA).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_PANAMA).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_panama_as_panama_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_PANAMA).sub_language(), SubLanguage::Panama);
+        assert_eq!(
+            super::from_lang_id(SPANISH_PANAMA).sub_language(),
+            SubLanguage::Panama
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_dominican_republic_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_DOMINICAN_REPUBLIC).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_DOMINICAN_REPUBLIC).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_dominican_republic_as_dominican_republic_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_DOMINICAN_REPUBLIC).sub_language(), SubLanguage::DominicanRepublic);
+        assert_eq!(
+            super::from_lang_id(SPANISH_DOMINICAN_REPUBLIC).sub_language(),
+            SubLanguage::DominicanRepublic
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_venezuela_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_VENEZUELA).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_VENEZUELA).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_venezuela_as_venezuela_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_VENEZUELA).sub_language(), SubLanguage::Venezuela);
+        assert_eq!(
+            super::from_lang_id(SPANISH_VENEZUELA).sub_language(),
+            SubLanguage::Venezuela
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_colombia_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_COLOMBIA).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_COLOMBIA).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_colombia_as_colombia_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_COLOMBIA).sub_language(), SubLanguage::Colombia);
+        assert_eq!(
+            super::from_lang_id(SPANISH_COLOMBIA).sub_language(),
+            SubLanguage::Colombia
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_peru_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_PERU).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_PERU).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_peru_as_peru_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_PERU).sub_language(), SubLanguage::Peru);
+        assert_eq!(
+            super::from_lang_id(SPANISH_PERU).sub_language(),
+            SubLanguage::Peru
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_argentina_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_ARGENTINA).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_ARGENTINA).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_argentina_as_argentina_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_ARGENTINA).sub_language(), SubLanguage::Argentina);
+        assert_eq!(
+            super::from_lang_id(SPANISH_ARGENTINA).sub_language(),
+            SubLanguage::Argentina
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_ecuador_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_ECUADOR).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_ECUADOR).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_ecuador_as_ecuador_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_ECUADOR).sub_language(), SubLanguage::Ecuador);
+        assert_eq!(
+            super::from_lang_id(SPANISH_ECUADOR).sub_language(),
+            SubLanguage::Ecuador
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_chile_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_CHILE).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_CHILE).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_chile_as_chile_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_CHILE).sub_language(), SubLanguage::Chile);
+        assert_eq!(
+            super::from_lang_id(SPANISH_CHILE).sub_language(),
+            SubLanguage::Chile
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_uruguay_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_URUGUAY).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_URUGUAY).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_uruguay_as_uruguay_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_URUGUAY).sub_language(), SubLanguage::Uruguay);
+        assert_eq!(
+            super::from_lang_id(SPANISH_URUGUAY).sub_language(),
+            SubLanguage::Uruguay
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_paraguay_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_PARAGUAY).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_PARAGUAY).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_paraguay_as_paraguay_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_PARAGUAY).sub_language(), SubLanguage::Paraguay);
+        assert_eq!(
+            super::from_lang_id(SPANISH_PARAGUAY).sub_language(),
+            SubLanguage::Paraguay
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_bolivia_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_BOLIVIA).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_BOLIVIA).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_bolivia_as_bolivia_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_BOLIVIA).sub_language(), SubLanguage::Bolivia);
+        assert_eq!(
+            super::from_lang_id(SPANISH_BOLIVIA).sub_language(),
+            SubLanguage::Bolivia
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_el_salvador_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_EL_SALVADOR).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_EL_SALVADOR).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_el_salvador_as_el_salvador_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_EL_SALVADOR).sub_language(), SubLanguage::ElSalvador);
+        assert_eq!(
+            super::from_lang_id(SPANISH_EL_SALVADOR).sub_language(),
+            SubLanguage::ElSalvador
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_honduras_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_HONDURAS).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_HONDURAS).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_honduras_as_honduras_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_HONDURAS).sub_language(), SubLanguage::Honduras);
+        assert_eq!(
+            super::from_lang_id(SPANISH_HONDURAS).sub_language(),
+            SubLanguage::Honduras
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_nicaragua_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_NICARAGUA).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_NICARAGUA).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_nicaragua_as_nicaragua_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_NICARAGUA).sub_language(), SubLanguage::Nicaragua);
+        assert_eq!(
+            super::from_lang_id(SPANISH_NICARAGUA).sub_language(),
+            SubLanguage::Nicaragua
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_puerto_rico_as_spanish_language() {
-        assert_eq!(super::from_lang_id(SPANISH_PUERTO_RICO).primary_language(), PrimaryLanguage::Spanish);
+        assert_eq!(
+            super::from_lang_id(SPANISH_PUERTO_RICO).primary_language(),
+            PrimaryLanguage::Spanish
+        );
     }
 
     #[test]
     fn it_recognizes_spanish_from_puerto_rico_as_puerto_rico_sub_language() {
-        assert_eq!(super::from_lang_id(SPANISH_PUERTO_RICO).sub_language(), SubLanguage::PuertoRico);
+        assert_eq!(
+            super::from_lang_id(SPANISH_PUERTO_RICO).sub_language(),
+            SubLanguage::PuertoRico
+        );
     }
 
     #[test]
     fn it_recognizes_sutu_as_sutu_language() {
-        assert_eq!(super::from_lang_id(SUTU).primary_language(), PrimaryLanguage::Sutu);
+        assert_eq!(
+            super::from_lang_id(SUTU).primary_language(),
+            PrimaryLanguage::Sutu
+        );
     }
 
     #[test]
     fn it_recognizes_swahili_as_swahili_language() {
-        assert_eq!(super::from_lang_id(SWAHILI_KENYA).primary_language(), PrimaryLanguage::Swahili);
+        assert_eq!(
+            super::from_lang_id(SWAHILI_KENYA).primary_language(),
+            PrimaryLanguage::Swahili
+        );
     }
 
     #[test]
     fn it_recognizes_swedish_as_swedish_language() {
-        assert_eq!(super::from_lang_id(SWEDISH).primary_language(), PrimaryLanguage::Swedish);
+        assert_eq!(
+            super::from_lang_id(SWEDISH).primary_language(),
+            PrimaryLanguage::Swedish
+        );
     }
 
     #[test]
     fn it_recognizes_swedish_as_standard_sub_language() {
-        assert_eq!(super::from_lang_id(SWEDISH).sub_language(), SubLanguage::Standard);
+        assert_eq!(
+            super::from_lang_id(SWEDISH).sub_language(),
+            SubLanguage::Standard
+        );
     }
 
     #[test]
     fn it_recognizes_swedish_from_finland_as_swedish_language() {
-        assert_eq!(super::from_lang_id(SWEDISH_FINLAND).primary_language(), PrimaryLanguage::Swedish);
+        assert_eq!(
+            super::from_lang_id(SWEDISH_FINLAND).primary_language(),
+            PrimaryLanguage::Swedish
+        );
     }
 
     #[test]
     fn it_recognizes_swedish_from_finland_as_finland_sub_language() {
-        assert_eq!(super::from_lang_id(SWEDISH_FINLAND).sub_language(), SubLanguage::Finland);
+        assert_eq!(
+            super::from_lang_id(SWEDISH_FINLAND).sub_language(),
+            SubLanguage::Finland
+        );
     }
 
     #[test]
     fn it_recognizes_tamil_as_tamil_language() {
-        assert_eq!(super::from_lang_id(TAMIL).primary_language(), PrimaryLanguage::Tamil);
+        assert_eq!(
+            super::from_lang_id(TAMIL).primary_language(),
+            PrimaryLanguage::Tamil
+        );
     }
 
     #[test]
     fn it_recognizes_tatar_as_tatar_language() {
-        assert_eq!(super::from_lang_id(TATAR_TATARSTAN).primary_language(), PrimaryLanguage::Tatar);
+        assert_eq!(
+            super::from_lang_id(TATAR_TATARSTAN).primary_language(),
+            PrimaryLanguage::Tatar
+        );
     }
 
     #[test]
     fn it_recognizes_telugu_as_telugu_language() {
-        assert_eq!(super::from_lang_id(TELUGU).primary_language(), PrimaryLanguage::Telugu);
+        assert_eq!(
+            super::from_lang_id(TELUGU).primary_language(),
+            PrimaryLanguage::Telugu
+        );
     }
 
     #[test]
     fn it_recognizes_thai_as_thai_language() {
-        assert_eq!(super::from_lang_id(THAI).primary_language(), PrimaryLanguage::Thai);
+        assert_eq!(
+            super::from_lang_id(THAI).primary_language(),
+            PrimaryLanguage::Thai
+        );
     }
 
     #[test]
     fn it_recognizes_turkish_as_turkish_language() {
-        assert_eq!(super::from_lang_id(TURKISH).primary_language(), PrimaryLanguage::Turkish);
+        assert_eq!(
+            super::from_lang_id(TURKISH).primary_language(),
+            PrimaryLanguage::Turkish
+        );
     }
 
     #[test]
     fn it_recognizes_ukrainian_as_ukrainian_language() {
-        assert_eq!(super::from_lang_id(UKRAINIAN).primary_language(), PrimaryLanguage::Ukrainian);
+        assert_eq!(
+            super::from_lang_id(UKRAINIAN).primary_language(),
+            PrimaryLanguage::Ukrainian
+        );
     }
 
     #[test]
     fn it_recognizes_urdu_from_pakistan_as_urdu_language() {
-        assert_eq!(super::from_lang_id(URDU_PAKISTAN).primary_language(), PrimaryLanguage::Urdu);
+        assert_eq!(
+            super::from_lang_id(URDU_PAKISTAN).primary_language(),
+            PrimaryLanguage::Urdu
+        );
     }
 
     #[test]
     fn it_recognizes_urdu_from_pakistan_as_pakistan_sub_language() {
-        assert_eq!(super::from_lang_id(URDU_PAKISTAN).sub_language(), SubLanguage::Pakistan);
+        assert_eq!(
+            super::from_lang_id(URDU_PAKISTAN).sub_language(),
+            SubLanguage::Pakistan
+        );
     }
 
     #[test]
     fn it_recognizes_urdu_from_india_as_urdu_language() {
-        assert_eq!(super::from_lang_id(URDU_INDIA).primary_language(), PrimaryLanguage::Urdu);
+        assert_eq!(
+            super::from_lang_id(URDU_INDIA).primary_language(),
+            PrimaryLanguage::Urdu
+        );
     }
 
     #[test]
     fn it_recognizes_urdu_from_india_as_india_sub_language() {
-        assert_eq!(super::from_lang_id(URDU_INDIA).sub_language(), SubLanguage::India);
+        assert_eq!(
+            super::from_lang_id(URDU_INDIA).sub_language(),
+            SubLanguage::India
+        );
     }
 
     #[test]
     fn it_recognizes_uzbek_latin_as_uzbek_language() {
-        assert_eq!(super::from_lang_id(UZBEK_LATIN).primary_language(), PrimaryLanguage::Uzbek);
+        assert_eq!(
+            super::from_lang_id(UZBEK_LATIN).primary_language(),
+            PrimaryLanguage::Uzbek
+        );
     }
 
     #[test]
     fn it_recognizes_uzbek_latin_as_latin_sub_language() {
-        assert_eq!(super::from_lang_id(UZBEK_LATIN).sub_language(), SubLanguage::Latin);
+        assert_eq!(
+            super::from_lang_id(UZBEK_LATIN).sub_language(),
+            SubLanguage::Latin
+        );
     }
 
     #[test]
     fn it_recognizes_uzbek_cyrillic_as_uzbek_language() {
-        assert_eq!(super::from_lang_id(UZBEK_CYRILLIC).primary_language(), PrimaryLanguage::Uzbek);
+        assert_eq!(
+            super::from_lang_id(UZBEK_CYRILLIC).primary_language(),
+            PrimaryLanguage::Uzbek
+        );
     }
 
     #[test]
     fn it_recognizes_uzbek_cyrillic_as_cyrillic_sub_language() {
-        assert_eq!(super::from_lang_id(UZBEK_CYRILLIC).sub_language(), SubLanguage::Cyrillic);
+        assert_eq!(
+            super::from_lang_id(UZBEK_CYRILLIC).sub_language(),
+            SubLanguage::Cyrillic
+        );
     }
 
     #[test]
     fn it_recognizes_vietnamese_as_vietnamese_language() {
-        assert_eq!(super::from_lang_id(VIETNAMESE).primary_language(), PrimaryLanguage::Vietnamese);
+        assert_eq!(
+            super::from_lang_id(VIETNAMESE).primary_language(),
+            PrimaryLanguage::Vietnamese
+        );
     }
 
     #[test]
     fn it_recognizes_hid_usage_data_descriptor_as_hid_language() {
-        assert_eq!(super::from_lang_id(HID_USAGE_DATA_DESCRIPTOR).primary_language(), PrimaryLanguage::HID);
+        assert_eq!(
+            super::from_lang_id(HID_USAGE_DATA_DESCRIPTOR).primary_language(),
+            PrimaryLanguage::HID
+        );
     }
 
     #[test]
     fn it_recognizes_hid_usage_data_descriptor_as_usage_data_descriptor_sub_language() {
-        assert_eq!(super::from_lang_id(HID_USAGE_DATA_DESCRIPTOR).sub_language(), SubLanguage::UsageDataDescriptor);
+        assert_eq!(
+            super::from_lang_id(HID_USAGE_DATA_DESCRIPTOR).sub_language(),
+            SubLanguage::UsageDataDescriptor
+        );
     }
 
     #[test]
     fn it_recognizes_hid_vendor_defined_1_as_hid_language() {
-        assert_eq!(super::from_lang_id(HID_VENDOR_DEFINED_1).primary_language(), PrimaryLanguage::HID);
+        assert_eq!(
+            super::from_lang_id(HID_VENDOR_DEFINED_1).primary_language(),
+            PrimaryLanguage::HID
+        );
     }
 
     #[test]
     fn it_recognizes_hid_vendor_defined_1_as_vendor_defined_1_sub_language() {
-        assert_eq!(super::from_lang_id(HID_VENDOR_DEFINED_1).sub_language(), SubLanguage::VendorDefined1);
+        assert_eq!(
+            super::from_lang_id(HID_VENDOR_DEFINED_1).sub_language(),
+            SubLanguage::VendorDefined1
+        );
     }
 
     #[test]
     fn it_recognizes_hid_vendor_defined_2_as_hid_language() {
-        assert_eq!(super::from_lang_id(HID_VENDOR_DEFINED_2).primary_language(), PrimaryLanguage::HID);
+        assert_eq!(
+            super::from_lang_id(HID_VENDOR_DEFINED_2).primary_language(),
+            PrimaryLanguage::HID
+        );
     }
 
     #[test]
     fn it_recognizes_hid_vendor_defined_1_as_vendor_defined_2_sub_language() {
-        assert_eq!(super::from_lang_id(HID_VENDOR_DEFINED_2).sub_language(), SubLanguage::VendorDefined2);
+        assert_eq!(
+            super::from_lang_id(HID_VENDOR_DEFINED_2).sub_language(),
+            SubLanguage::VendorDefined2
+        );
     }
 
     #[test]
     fn it_recognizes_hid_vendor_defined_3_as_hid_language() {
-        assert_eq!(super::from_lang_id(HID_VENDOR_DEFINED_3).primary_language(), PrimaryLanguage::HID);
+        assert_eq!(
+            super::from_lang_id(HID_VENDOR_DEFINED_3).primary_language(),
+            PrimaryLanguage::HID
+        );
     }
 
     #[test]
     fn it_recognizes_hid_vendor_defined_1_as_vendor_defined_3_sub_language() {
-        assert_eq!(super::from_lang_id(HID_VENDOR_DEFINED_3).sub_language(), SubLanguage::VendorDefined3);
+        assert_eq!(
+            super::from_lang_id(HID_VENDOR_DEFINED_3).sub_language(),
+            SubLanguage::VendorDefined3
+        );
     }
 
     #[test]
     fn it_recognizes_hid_vendor_defined_4_as_hid_language() {
-        assert_eq!(super::from_lang_id(HID_VENDOR_DEFINED_4).primary_language(), PrimaryLanguage::HID);
+        assert_eq!(
+            super::from_lang_id(HID_VENDOR_DEFINED_4).primary_language(),
+            PrimaryLanguage::HID
+        );
     }
 
     #[test]
     fn it_recognizes_hid_vendor_defined_1_as_vendor_defined_4_sub_language() {
-        assert_eq!(super::from_lang_id(HID_VENDOR_DEFINED_4).sub_language(), SubLanguage::VendorDefined4);
+        assert_eq!(
+            super::from_lang_id(HID_VENDOR_DEFINED_4).sub_language(),
+            SubLanguage::VendorDefined4
+        );
     }
 
     #[test]
     fn it_recognizes_other_as_other_language() {
-        assert_eq!(super::from_lang_id(0xFFFF).primary_language(), PrimaryLanguage::Other(PRIMARY_LANGUAGE_MASK));
+        assert_eq!(
+            super::from_lang_id(0xFFFF).primary_language(),
+            PrimaryLanguage::Other(PRIMARY_LANGUAGE_MASK)
+        );
     }
 
     #[test]
     fn it_recognizes_other_as_other_sub_language() {
-        assert_eq!(super::from_lang_id(0xFFFF).sub_language(), SubLanguage::Other(SUB_LANGUAGE_MASK));
+        assert_eq!(
+            super::from_lang_id(0xFFFF).sub_language(),
+            SubLanguage::Other(SUB_LANGUAGE_MASK)
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,28 @@
 //! This crate provides a safe wrapper around the native `libusb` library.
 
 extern crate bit_set;
-extern crate libusb_sys as libusb;
 extern crate libc;
+extern crate libusb_sys as libusb;
 
-pub use version::{LibraryVersion, version};
-pub use error::{Result, Error};
+pub use error::{Error, Result};
+pub use version::{version, LibraryVersion};
 
 pub use context::{Context, LogLevel};
-pub use device_list::{DeviceList, Devices};
 pub use device::Device;
 pub use device_handle::DeviceHandle;
+pub use device_list::{DeviceList, Devices};
 
-pub use fields::{Speed, TransferType, SyncType, UsageType, Direction, RequestType, Recipient, Version, request_type};
-pub use device_descriptor::DeviceDescriptor;
 pub use config_descriptor::{ConfigDescriptor, Interfaces};
-pub use interface_descriptor::{Interface, InterfaceDescriptors, InterfaceDescriptor, EndpointDescriptors};
+pub use device_descriptor::DeviceDescriptor;
 pub use endpoint_descriptor::EndpointDescriptor;
+pub use fields::{
+    request_type, Direction, Recipient, RequestType, Speed, SyncType, TransferType, UsageType,
+    Version,
+};
+pub use interface_descriptor::{
+    EndpointDescriptors, Interface, InterfaceDescriptor, InterfaceDescriptors,
+};
 pub use language::{Language, PrimaryLanguage, SubLanguage};
-
 
 #[cfg(test)]
 #[macro_use]
@@ -29,13 +33,13 @@ mod error;
 mod version;
 
 mod context;
-mod device_list;
 mod device;
 mod device_handle;
+mod device_list;
 
-mod fields;
-mod device_descriptor;
 mod config_descriptor;
-mod interface_descriptor;
+mod device_descriptor;
 mod endpoint_descriptor;
+mod fields;
+mod interface_descriptor;
 mod language;

--- a/src/version.rs
+++ b/src/version.rs
@@ -39,14 +39,11 @@ impl LibraryVersion {
             Ok(s) => {
                 if s.len() > 0 {
                     Some(s)
-                }
-                else {
+                } else {
                     None
                 }
-            },
-            Err(_) => {
-                None
-            },
+            }
+            Err(_) => None,
         }
     }
 }
@@ -67,9 +64,7 @@ impl fmt::Debug for LibraryVersion {
 
 /// Returns a structure with the version of the running libusb library.
 pub fn version() -> LibraryVersion {
-    let version: &'static libusb_version = unsafe {
-        mem::transmute(libusb_get_version())
-    };
+    let version: &'static libusb_version = unsafe { mem::transmute(libusb_get_version()) };
 
     LibraryVersion { inner: version }
 }


### PR DESCRIPTION
Yes, this is probably too many changes in one PR but if you're interested I'm willing to do the work in splitting them out.

323bce9 just runs all the code through rustfmt.
dd035dc removes a couple of `mut` declarations the linter was complaining about.
b4cee90 updates everything to Rust 2018.
fc27e0c is the big one: it removes the explicit lifetime declarations and uses Rc instead to maintain pointers without needing consumers of the library to explicitly declare lifetimes too.

All tests still pass.
