### PR TITLE
Add methods to retrieve "extra" bytes from config and interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,116 @@
+[root]
+name = "libusb"
+version = "0.3.0"
+dependencies = [
+ "bit-set 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libusb-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bit-vec 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libusb-sys"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+

--- a/src/config_descriptor.rs
+++ b/src/config_descriptor.rs
@@ -79,6 +79,20 @@ impl ConfigDescriptor {
 
         Interfaces { iter: interfaces.iter() }
     }
+
+    /// Returns the extra bytes of the configuration descriptor if any.
+    pub fn extra(&self) -> Option<&[u8]> {
+        unsafe {
+            if (*self.descriptor).extra_length == 0 {
+                None
+            } else {
+                Some(slice::from_raw_parts(
+                    (*self.descriptor).extra,
+                    (*self.descriptor).extra_length as usize,
+                ))
+            }
+        }
+    }
 }
 
 impl fmt::Debug for ConfigDescriptor {

--- a/src/interface_descriptor.rs
+++ b/src/interface_descriptor.rs
@@ -102,6 +102,20 @@ impl<'a> InterfaceDescriptor<'a> {
 
         EndpointDescriptors { iter: endpoints.iter() }
     }
+
+    /// Returns the extra bytes of the interface descriptor if any.
+    pub fn extra(&self) -> Option<&[u8]> {
+        if self.descriptor.extra_length == 0 {
+            None
+        } else {
+            unsafe {
+                Some(slice::from_raw_parts(
+                    self.descriptor.extra,
+                    self.descriptor.extra_length as usize,
+                ))
+            }
+        }
+    }
 }
 
 impl<'a> fmt::Debug for InterfaceDescriptor<'a> {


### PR DESCRIPTION
Hello @dcuddeback :wave: 

Thanks for the great crate! :heart: 

I submit this PR that will allow the user to retrieve the "extra" bytes from the configuration descriptor and the interface descriptor.

This is useful for me to implement a DFU crate as documented [here](https://usb.org/sites/default/files/DFU_1.1.pdf) in page 13.

